### PR TITLE
Feat/15 로그인 & 회원가입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
 	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
 
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/pickRAP/server/common/BaseExceptionStatus.java
+++ b/src/main/java/pickRAP/server/common/BaseExceptionStatus.java
@@ -7,10 +7,15 @@ import org.springframework.http.HttpStatus;
 public enum BaseExceptionStatus {
 
     // 성공
-    SUCCESS(1000, "요청 성공"),
+    SUCCESS(HttpStatus.OK, 1000, "요청 성공"),
     // 인증
-    UN_AUTHORIZED(2000, "토큰 검증 실패"),
-    SC_FORBIDDEN(2001, "권한 없음");
+    UN_AUTHORIZED(HttpStatus.UNAUTHORIZED, 2000, "토큰 검증 실패"),
+    SC_FORBIDDEN(HttpStatus.FORBIDDEN, 2001, "권한 없음"),
+    INVALID_EMAIL(HttpStatus.BAD_REQUEST, 2002, "이메일 형식을 확인해주세요"),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, 2003, "비밀번호 형식을 확인해주세요"),
+    EXIST_ACCOUNT(HttpStatus.BAD_REQUEST, 2004, "이미 존재하는 회원입니다"),
+    FAIL_LOGIN(HttpStatus.BAD_REQUEST, 2005, "로그인 실패"),
+    INVALID_EMAIL_CODE(HttpStatus.BAD_REQUEST, 2006, "인증코드 검증실패");
 
     // 회원
 
@@ -23,11 +28,15 @@ public enum BaseExceptionStatus {
 
     // 분석&추천
 
+    // 커뮤니티
 
+
+    private HttpStatus httpStatus;
     private final int code;
     private final String message;
 
-    private BaseExceptionStatus(int code, String message) {
+    private BaseExceptionStatus(HttpStatus httpStatus, int code, String message) {
+        this.httpStatus = httpStatus;
         this.code = code;
         this.message = message;
     }

--- a/src/main/java/pickRAP/server/common/BaseResponse.java
+++ b/src/main/java/pickRAP/server/common/BaseResponse.java
@@ -1,11 +1,14 @@
 package pickRAP.server.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
 import static pickRAP.server.common.BaseExceptionStatus.*;
 
 @Data
+@JsonPropertyOrder({"code", "message", "data"})
 public class BaseResponse<T> {
 
     private int code;

--- a/src/main/java/pickRAP/server/common/GlobalExceptionHandler.java
+++ b/src/main/java/pickRAP/server/common/GlobalExceptionHandler.java
@@ -1,17 +1,25 @@
 package pickRAP.server.common;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static pickRAP.server.common.BaseExceptionStatus.*;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public BaseResponse handleBaseException(BaseException e) {
-        return new BaseResponse(e.getStatus());
+    public ResponseEntity handleBaseException(BaseException e) {
+        return ResponseEntity.status(e.getStatus().getHttpStatus()).body(new BaseResponse<>(e.getStatus()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity handleBadCredentialsException(BadCredentialsException e) {
+        return ResponseEntity.status(FAIL_LOGIN.getHttpStatus()).body(new BaseResponse<>(FAIL_LOGIN));
     }
 
 }

--- a/src/main/java/pickRAP/server/config/security/jwt/JwtFilter.java
+++ b/src/main/java/pickRAP/server/config/security/jwt/JwtFilter.java
@@ -18,9 +18,6 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
-    public static final String AUTHORIZATION_HEADER = "Authorization";
-    public static final String BEARER_PREFIX = "Bearer ";
-
     private final TokenProvider tokenProvider;
 
     /**
@@ -36,7 +33,7 @@ public class JwtFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request,
         HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
 
-        String jwt = resolveToken(request);
+        String jwt = tokenProvider.resolveToken(request);
 
         if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
             Authentication authentication = tokenProvider.getAuthentication(jwt);
@@ -46,17 +43,4 @@ public class JwtFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    /**
-     *
-     * @param request
-     * @return 토큰 반환
-     */
-    private String resolveToken(HttpServletRequest request) throws IOException {
-
-        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-            return bearerToken.substring(7);
-        }
-        return null;
-    }
 }

--- a/src/main/java/pickRAP/server/config/security/jwt/TokenProvider.java
+++ b/src/main/java/pickRAP/server/config/security/jwt/TokenProvider.java
@@ -13,7 +13,10 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
 import java.security.Key;
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,6 +33,8 @@ public class TokenProvider {
     private static final String AUTHORITIES_KEY = "auth";
     private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;  //30분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  //7일
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
 
     private final Key key;
 
@@ -131,6 +136,21 @@ public class TokenProvider {
         } catch (ExpiredJwtException e) {
             return e.getClaims();
         }
+    }
+
+    /**
+     * <<토큰 반환>>
+     * @param request
+     * @return
+     * @throws IOException
+     */
+    public String resolveToken(HttpServletRequest request) throws IOException {
+
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 
 }

--- a/src/main/java/pickRAP/server/controller/AuthController.java
+++ b/src/main/java/pickRAP/server/controller/AuthController.java
@@ -1,0 +1,130 @@
+package pickRAP.server.controller;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pickRAP.server.common.BaseException;
+import pickRAP.server.common.BaseResponse;
+import pickRAP.server.controller.dto.auth.MemberEmailRequest;
+import pickRAP.server.controller.dto.auth.MemberSignInRequest;
+import pickRAP.server.controller.dto.auth.MemberSignUpRequest;
+import pickRAP.server.controller.dto.auth.MemberVerifyCodeRequest;
+import pickRAP.server.service.auth.AuthService;
+import pickRAP.server.service.auth.VerifyCodeService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import static pickRAP.server.common.BaseExceptionStatus.*;
+
+@Slf4j
+@RequestMapping("/auth")
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+    private final VerifyCodeService verifyCodeService;
+    private static final Pattern EMAIL = Pattern.compile("^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",Pattern.CASE_INSENSITIVE);
+    private static final Pattern PASSWORD = Pattern.compile("^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,16}$",Pattern.CASE_INSENSITIVE);
+    /*
+    회원가입
+     */
+    @PostMapping("/sign-up")
+    @ApiOperation(value = "회원가입", notes = "이메일 형식 검사 + 비밀번호 형식(영문 + 숫자 8~16자)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "400", description = "2002-이메일형식예외, 2003-비밀번호형식예외, 2004-이미존재하는회원"),
+            @ApiResponse(responseCode = "500", description = "서버 예외")
+    })
+    public ResponseEntity<BaseResponse> signUp(@RequestBody MemberSignUpRequest memberSignUpRequest) {
+        if (!isRegexEmail(memberSignUpRequest.getEmail())) {
+            throw new BaseException(INVALID_EMAIL);
+        }
+        if (!isRegexPassword(memberSignUpRequest.getPassword())) {
+            throw new BaseException(INVALID_PASSWORD);
+        }
+        authService.signUp(memberSignUpRequest);
+        return ResponseEntity.ok(new BaseResponse<>(SUCCESS));
+    }
+
+    private boolean isRegexEmail(String email) {
+        return EMAIL.matcher(email).find();
+    }
+
+    private boolean isRegexPassword(String password) {
+        return PASSWORD.matcher(password).find();
+    }
+
+    /*
+    이메일 인증
+     */
+    @PostMapping("/send-email")
+    @ApiOperation(value = "이메일 인증", notes = "이메일 인증코드 보내기")
+    @ApiResponses({
+            @ApiResponse(responseCode = "400", description = "2002-이메일형식예외"),
+            @ApiResponse(responseCode = "500", description = "서버 예외")
+    })
+    public ResponseEntity<BaseResponse> sendEmail(@RequestBody MemberEmailRequest memberEmailRequest) {
+        if (!isRegexEmail(memberEmailRequest.getEmail())) {
+            throw new BaseException(INVALID_EMAIL);
+        }
+        verifyCodeService.createVerifyCode(memberEmailRequest.getEmail());
+        return ResponseEntity.ok(new BaseResponse<>(SUCCESS));
+    }
+
+    /*
+    인증코드 검증
+     */
+    @PostMapping("/verify-email")
+    @ApiOperation(value = "이메일 인증코드 검증", notes = "이메일 인증코드 검증")
+    @ApiResponses({
+            @ApiResponse(responseCode = "400", description = "2006-인증코드 검증실패"),
+            @ApiResponse(responseCode = "500", description = "서버 예외")
+    })
+    public ResponseEntity<BaseResponse> verifyEmail(@RequestBody MemberVerifyCodeRequest memberVerifyCodeRequest) {
+        verifyCodeService.verifyCode(memberVerifyCodeRequest.getCode());
+        return ResponseEntity.ok(new BaseResponse<>(SUCCESS));
+    }
+
+
+    /*
+    로그인
+     */
+
+    @PostMapping("/sign-in")
+    @ApiOperation(value = "로그인", notes = "유저 로그인")
+    @ApiResponses({
+            @ApiResponse(responseCode = "400", description = "2005-로그인실패"),
+            @ApiResponse(responseCode = "500", description = "서버 예외")
+    })
+    public ResponseEntity<BaseResponse> signIn(@RequestBody MemberSignInRequest memberSignInRequest, HttpServletResponse response) {
+        String accessToken = authService.signIn(memberSignInRequest);
+        response.setHeader("Authorization", "Bearer "+accessToken);
+        return ResponseEntity.ok(new BaseResponse<>(SUCCESS));
+    }
+
+    /*
+    재발급
+     */
+    @PostMapping("/reissue")
+    @ApiOperation(value = "재발급", notes = "토큰 재발급")
+    @ApiResponses({
+            @ApiResponse(responseCode = "401", description = "2000-토큰만료"),
+            @ApiResponse(responseCode = "500", description = "서버 예외")
+    })
+    public ResponseEntity<BaseResponse> refresh(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String newAccessToken = authService.reissue(request);
+        response.setHeader("Authorization", "Bearer "+newAccessToken);
+        return ResponseEntity.ok(new BaseResponse<>(SUCCESS));
+    }
+}

--- a/src/main/java/pickRAP/server/controller/MemberController.java
+++ b/src/main/java/pickRAP/server/controller/MemberController.java
@@ -1,0 +1,35 @@
+package pickRAP.server.controller;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pickRAP.server.common.BaseResponse;
+import pickRAP.server.service.auth.AuthService;
+
+import static pickRAP.server.common.BaseExceptionStatus.*;
+
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final AuthService authService;
+
+    /*
+    로그아웃
+     */
+    @PostMapping("/log-out")
+    @ApiOperation(value = "로그아웃", notes = "redis 토큰 삭제")
+    @ApiResponses({
+            @ApiResponse(responseCode = "500", description = "서버 예외")
+    })
+    public ResponseEntity<BaseResponse> logout() {
+        authService.logout();
+        return ResponseEntity.ok(new BaseResponse(SUCCESS));
+    }
+
+}

--- a/src/main/java/pickRAP/server/controller/dto/auth/MemberEmailRequest.java
+++ b/src/main/java/pickRAP/server/controller/dto/auth/MemberEmailRequest.java
@@ -1,0 +1,9 @@
+package pickRAP.server.controller.dto.auth;
+
+import lombok.Data;
+
+@Data
+public class MemberEmailRequest {
+
+    private String email;
+}

--- a/src/main/java/pickRAP/server/controller/dto/auth/MemberSignInRequest.java
+++ b/src/main/java/pickRAP/server/controller/dto/auth/MemberSignInRequest.java
@@ -1,0 +1,12 @@
+package pickRAP.server.controller.dto.auth;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+
+@Data
+public class MemberSignInRequest {
+
+    private String email;
+
+    private String password;
+}

--- a/src/main/java/pickRAP/server/controller/dto/auth/MemberSignUpRequest.java
+++ b/src/main/java/pickRAP/server/controller/dto/auth/MemberSignUpRequest.java
@@ -1,0 +1,14 @@
+package pickRAP.server.controller.dto.auth;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+
+@Data
+public class MemberSignUpRequest {
+
+    private String email;
+
+    private String password;
+
+    private String name;
+}

--- a/src/main/java/pickRAP/server/controller/dto/auth/MemberVerifyCodeRequest.java
+++ b/src/main/java/pickRAP/server/controller/dto/auth/MemberVerifyCodeRequest.java
@@ -1,0 +1,9 @@
+package pickRAP.server.controller.dto.auth;
+
+import lombok.Data;
+
+@Data
+public class MemberVerifyCodeRequest {
+
+    private String code;
+}

--- a/src/main/java/pickRAP/server/domain/member/SocialType.java
+++ b/src/main/java/pickRAP/server/domain/member/SocialType.java
@@ -1,5 +1,5 @@
 package pickRAP.server.domain.member;
 
 public enum SocialType {
-    KAKAO, NAVER
+    NONE, KAKAO, NAVER
 }

--- a/src/main/java/pickRAP/server/repository/member/MemberRepository.java
+++ b/src/main/java/pickRAP/server/repository/member/MemberRepository.java
@@ -8,4 +8,7 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+
 }

--- a/src/main/java/pickRAP/server/service/auth/AuthService.java
+++ b/src/main/java/pickRAP/server/service/auth/AuthService.java
@@ -1,0 +1,112 @@
+package pickRAP.server.service.auth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import pickRAP.server.common.BaseException;
+import pickRAP.server.common.BaseExceptionStatus;
+import pickRAP.server.config.security.config.SecurityUtil;
+import pickRAP.server.config.security.jwt.TokenDto;
+import pickRAP.server.config.security.jwt.TokenProvider;
+import pickRAP.server.controller.dto.auth.MemberSignInRequest;
+import pickRAP.server.controller.dto.auth.MemberSignUpRequest;
+import pickRAP.server.domain.member.Member;
+import pickRAP.server.domain.member.SocialType;
+import pickRAP.server.repository.member.MemberRepository;
+import pickRAP.server.util.RedisClient;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.Optional;
+
+import static pickRAP.server.common.BaseExceptionStatus.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final TokenProvider tokenProvider;
+    private final RedisClient redisClient;
+    private final PasswordEncoder passwordEncoder;
+
+
+    /*
+    회원가입
+     */
+    public void signUp(MemberSignUpRequest memberSignUpRequest) {
+        if (memberRepository.existsByEmail(memberSignUpRequest.getEmail())){
+            throw new BaseException(EXIST_ACCOUNT);
+        }
+        memberRepository.save(Member.builder()
+                        .email(memberSignUpRequest.getEmail())
+                        .password(passwordEncoder.encode(memberSignUpRequest.getPassword()))
+                        .name(memberSignUpRequest.getName())
+                        .socialType(SocialType.NONE)
+                        .build()
+        );
+    }
+
+    /*
+    로그인
+     */
+    public String signIn(MemberSignInRequest memberSignInRequest) {
+        return authenticationMember(memberSignInRequest.getEmail(), memberSignInRequest.getPassword());
+    }
+
+
+    /*
+    재발급
+     */
+    public String reissue(HttpServletRequest request) throws IOException {
+        // 기존 accessToken 찾기
+        String accessToken = tokenProvider.resolveToken(request);
+        Authentication authentication = tokenProvider.getAuthentication(accessToken);
+
+        // redis의 refreshToken과의 검증
+        String refreshToken = Optional.ofNullable(redisClient.getValues(authentication.getName())).orElseThrow(
+                () -> new BaseException(UN_AUTHORIZED)
+        );
+        if(!tokenProvider.validateToken(refreshToken)){
+            throw new BaseException(UN_AUTHORIZED);
+        }
+
+        // 토큰 발급
+        return generateToken(authentication);
+    }
+
+    /*
+    사용자 검증
+     */
+    public String authenticationMember(String principal, String credentials) {
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                principal, credentials
+        );
+        return generateToken(authenticationManagerBuilder.getObject().authenticate(authenticationToken));
+    }
+
+
+    /*
+    토큰 생성
+     */
+    public String generateToken(Authentication authentication) {
+        TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
+        redisClient.setValues(authentication.getName(), tokenDto.getRefreshToken());
+        return tokenDto.getAccessToken();
+    }
+
+    /*
+    로그아웃
+     */
+    public void logout() {
+        redisClient.deleteValues(SecurityUtil.getCurrentMemberId());
+    }
+
+
+}

--- a/src/main/java/pickRAP/server/service/auth/EmailSenderService.java
+++ b/src/main/java/pickRAP/server/service/auth/EmailSenderService.java
@@ -1,0 +1,19 @@
+package pickRAP.server.service.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailSenderService {
+
+    private final JavaMailSender javaMailSender;
+
+    @Async
+    public void sendEmail(SimpleMailMessage email) {
+        javaMailSender.send(email);
+    }
+}

--- a/src/main/java/pickRAP/server/service/auth/VerifyCodeService.java
+++ b/src/main/java/pickRAP/server/service/auth/VerifyCodeService.java
@@ -1,0 +1,56 @@
+package pickRAP.server.service.auth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.stereotype.Service;
+import pickRAP.server.common.BaseException;
+import pickRAP.server.common.BaseExceptionStatus;
+import pickRAP.server.util.RedisClient;
+
+import java.util.Optional;
+import java.util.Random;
+
+import static pickRAP.server.common.BaseExceptionStatus.*;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class VerifyCodeService {
+
+    private final RedisClient redisClient;
+    private final EmailSenderService emailSenderService;
+
+    public void createVerifyCode(String receiverEmail) {
+        String code = createKey();
+
+        redisClient.setEmail(code);
+
+        SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
+        simpleMailMessage.setTo(receiverEmail);
+        simpleMailMessage.setSubject("[pickRAP] 이메일 인증");
+        simpleMailMessage.setText("["+code+"]인증번호를 입력해주세요.");
+        emailSenderService.sendEmail(simpleMailMessage);
+    }
+
+    public static String createKey() {
+        StringBuffer key = new StringBuffer();
+        Random rnd = new Random();
+
+        for (int i = 0; i < 6; i++) { // 인증코드 6자리
+            key.append((rnd.nextInt(10)));
+        }
+        return key.toString();
+    }
+
+    public void verifyCode(String code) {
+        // 인증코드 유효시간 만료
+        String findCode = Optional.ofNullable(redisClient.getValues(code)).orElseThrow(
+                () -> new BaseException(INVALID_EMAIL_CODE)
+        );
+        redisClient.deleteValues(code);
+    }
+
+
+
+}

--- a/src/main/java/pickRAP/server/util/RedisClient.java
+++ b/src/main/java/pickRAP/server/util/RedisClient.java
@@ -1,6 +1,7 @@
 package pickRAP.server.util;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
@@ -8,6 +9,7 @@ import pickRAP.server.config.security.jwt.TokenProvider;
 
 import java.time.Duration;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RedisClient {
@@ -21,6 +23,12 @@ public class RedisClient {
         values.set(key, data, Duration.ofDays(7));
     }
 
+    // 이메일 - 3분
+    public void setEmail(String key) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, key, Duration.ofMinutes(3));
+    }
+
 
     public String getValues(String key) {
         ValueOperations<String, String> values = redisTemplate.opsForValue();
@@ -30,6 +38,7 @@ public class RedisClient {
 
     //로그아웃
     public void deleteValues(String key) {
+        log.info("로그아웃");
         redisTemplate.delete(key);
     }
 }


### PR DESCRIPTION
## 📮 관련 이슈
- Resolved: #15 

## ⛳️ 작업 내용
- issue notion 기준으로 로그인 & 회원가입구현
- 이메일 인증코드 구현 (google smtp)
- 이메일 중복검사

## 🌱 PR 포인트
- https => ssl vs tls 에 따라서 smtp port번호 다르게 설정 필요
- {서버 도메인}/swagger-ui/index.html => api 명세

