### PR TITLE
:bug: Fix: 해시태그 무결성 위반 수정

### DIFF
--- a/src/main/java/pickRAP/server/service/scrap/ScrapService.java
+++ b/src/main/java/pickRAP/server/service/scrap/ScrapService.java
@@ -321,8 +321,8 @@ public class ScrapService {
     private void deleteHashtag(Long scrapId){
         List<ScrapHashtag> scrapHashtags = scrapHashtagRepository.findByScrapId(scrapId);
         for(ScrapHashtag scrapHashtag : scrapHashtags) {
-            scrapHashtagRepository.delete(scrapHashtag);
             hashtagRepository.delete(scrapHashtag.getHashtag());
+            scrapHashtagRepository.delete(scrapHashtag);
         }
     }
 


### PR DESCRIPTION
Fix: 해시태그 무결성 위반 수정

## 📮 관련 이슈
- Resolved: #130 

## ⛳️ 작업 내용

- hashtag, scrap_hashtag 데이터 무결성 위반 수정

## 🌱 PR 포인트

## 📸 스크린샷

## 📎 레퍼런스