### PR TITLE
Feat/revisiting content

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -2,18 +2,18 @@ version: 0.0
 os: linux  # Amazon Linux, RHEL, Ubuntu Server일 경우 "linux", Windows Server일 경우 "windows"
 files:
   - source: / # 인스턴스에 복사할 S3 파일의 경로, / 로 설정하면S3_BUCKET_NAME/PROJECT_NAME/GITHUB_SHA.zip
-    destination: /home/ubuntu/pickrap-server/ # 프로젝트 이름  # S3에서 가져온 파일을 저장할 위치
+    destination: /home/pickrap/pickrap-server/ # 프로젝트 이름  # S3에서 가져온 파일을 저장할 위치
     overwrite: yes # 덮어쓰기 허용
 
 # files에서 가져온 파일들에게 권한을 어떻게 적용해야하는지 지정
 permissions:
   - object: /
     pattern: "**"
-    owner: ubuntu
-    group: ubuntu
+    owner: ec2-user
+    group: ec2-user
 
 hooks:
   AfterInstall: # LifeCycle Event Hook의 이름을 의미
     - location: scripts/execute.sh # 스크립트의 위치. files.destination에 정의한 경로에 대한 상대경로롤 작성
       timeout: 600 # 실행 타임아웃. 최대 3600초
-      runas: ubuntu # 스크립트 실행 시 가장하는 사용자
+      runas: ec2-user # 스크립트 실행 시 가장하는 사용자

--- a/appspec.yml
+++ b/appspec.yml
@@ -9,11 +9,11 @@ files:
 permissions:
   - object: /
     pattern: "**"
-    owner: ec2-user
-    group: ec2-user
+    owner: pickrap
+    group: pickrap
 
 hooks:
   AfterInstall: # LifeCycle Event Hook의 이름을 의미
     - location: scripts/execute.sh # 스크립트의 위치. files.destination에 정의한 경로에 대한 상대경로롤 작성
       timeout: 600 # 실행 타임아웃. 최대 3600초
-      runas: ec2-user # 스크립트 실행 시 가장하는 사용자
+      runas: pickrap # 스크립트 실행 시 가장하는 사용자

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     volumes:
       - ./nginx:/etc/nginx/conf.d
       - /etc/letsencrypt:/etc/letsencrypt
-      - /var/log/nginx/web:/var/log/nginx/web
+      - /var/log/nginx/pickrap:/var/log/nginx/pickrap
     command:
       "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
     networks:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -28,7 +28,7 @@ server {
         server_name api.pickrap.com pickrap.com www.pickrap.com;
 
         ### 로그 설정 ###
-        access_log off;
+        access_log /var/log/nginx/pickrap/access.log pickrap_log;
         error_log /var/log/nginx/pickrap/error.log crit;
 
         server_tokens off;

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -28,7 +28,7 @@ server {
         server_name api.pickrap.com pickrap.com www.pickrap.com;
 
         ### 로그 설정 ###
-        access_log /var/log/nginx/pickrap/access.log pickrap_log;
+        access_log off;
         error_log /var/log/nginx/pickrap/error.log crit;
 
         server_tokens off;

--- a/scripts/execute.sh
+++ b/scripts/execute.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cd /home/ubuntu/pickrap-server
+cd /home/pickrap/pickrap-server
 sh scripts/switch-container.sh

--- a/scripts/switch-container.sh
+++ b/scripts/switch-container.sh
@@ -1,7 +1,7 @@
 # !/bin/bash
 
 RUNNING_APPLICATION=$(docker ps | grep blue)
-DEFAULT_CONF="/home/ubuntu/pickrap-server/nginx/default.conf"
+DEFAULT_CONF="/home/pickrap/pickrap-server/nginx/default.conf"
 
 if [ -z "$RUNNING_APPLICATION"  ];then
   echo "blue Deploy..."

--- a/scripts/switch-container.sh
+++ b/scripts/switch-container.sh
@@ -2,6 +2,7 @@
 
 RUNNING_APPLICATION=$(docker ps | grep blue)
 DEFAULT_CONF="/home/ubuntu/pickrap-server/nginx/default.conf"
+docker-compose up --build -d nginx
 
 if [ -z "$RUNNING_APPLICATION"  ];then
   echo "blue Deploy..."

--- a/scripts/switch-container.sh
+++ b/scripts/switch-container.sh
@@ -2,7 +2,6 @@
 
 RUNNING_APPLICATION=$(docker ps | grep blue)
 DEFAULT_CONF="/home/ubuntu/pickrap-server/nginx/default.conf"
-docker-compose up --build -d nginx
 
 if [ -z "$RUNNING_APPLICATION"  ];then
   echo "blue Deploy..."

--- a/src/main/java/pickRAP/server/controller/AnalysisController.java
+++ b/src/main/java/pickRAP/server/controller/AnalysisController.java
@@ -12,9 +12,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import pickRAP.server.common.BaseResponse;
 import pickRAP.server.controller.dto.analysis.AnalysisResponse;
+import pickRAP.server.controller.dto.analysis.RevisitResponse;
 import pickRAP.server.service.auth.AuthService;
 import pickRAP.server.service.hashtag.HashtagService;
+import pickRAP.server.service.scrap.RevisitScrapService;
 import pickRAP.server.service.text.TextService;
+
+import java.util.List;
 
 
 @Slf4j
@@ -26,6 +30,7 @@ public class AnalysisController {
     private final AuthService authService;
     private final HashtagService hashtagService;
     private final TextService textService;
+    private final RevisitScrapService revisitScrapService;
 
     @GetMapping
     @ApiOperation(value = "분석", notes = "해시태그 분석 & 텍스트 분석<br>" +
@@ -47,7 +52,21 @@ public class AnalysisController {
 
         // 텍스트 분석
         analysisResponse.setTexts(textService.getTextAnalysisResults(email));
-
         return ResponseEntity.ok(new BaseResponse(analysisResponse));
+    }
+
+    @GetMapping("/revisit")
+    @ApiOperation(value = "재방문 컨텐츠", notes = "재방문 컨텐츠 제공<br>" +
+            "parameter 설명<br>" +
+            "- filter : all(전체 목록), top(top3)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "500", description = "서버 예외")
+    })
+    public ResponseEntity<BaseResponse<List<RevisitResponse>>> getTop3RevisitContents(@RequestParam("filter") String filter) {
+        String email = authService.getUserEmail();
+
+        List<RevisitResponse> revisitResponses = revisitScrapService.getRevisitContents(email, filter);
+
+        return ResponseEntity.ok(new BaseResponse(revisitResponses));
     }
 }

--- a/src/main/java/pickRAP/server/controller/dto/analysis/RevisitResponse.java
+++ b/src/main/java/pickRAP/server/controller/dto/analysis/RevisitResponse.java
@@ -13,9 +13,12 @@ public class RevisitResponse {
     // TODO : preview 저장 추가 이후 update
     // String preview;
 
+    String title;
+
     @QueryProjection
-    public RevisitResponse(Long scrapId) {
+    public RevisitResponse(Long scrapId, String title) {
         this.scrapId = scrapId;
         // this.preview = preview;
+        this.title = title;
     }
 }

--- a/src/main/java/pickRAP/server/controller/dto/analysis/RevisitResponse.java
+++ b/src/main/java/pickRAP/server/controller/dto/analysis/RevisitResponse.java
@@ -1,0 +1,21 @@
+package pickRAP.server.controller.dto.analysis;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+
+@Data
+public class RevisitResponse {
+
+    @JsonProperty("scrap_id")
+    Long scrapId;
+
+    // TODO : preview 저장 추가 이후 update
+    // String preview;
+
+    @QueryProjection
+    public RevisitResponse(Long scrapId) {
+        this.scrapId = scrapId;
+        // this.preview = preview;
+    }
+}

--- a/src/main/java/pickRAP/server/domain/scrap/Scrap.java
+++ b/src/main/java/pickRAP/server/domain/scrap/Scrap.java
@@ -76,4 +76,9 @@ public class Scrap extends BaseEntity {
         this.title = title;
         this.memo = memo;
     }
+
+    public void updateRevisitRecord() {
+        this.revisitCount++;
+        this.revisitTime = LocalDateTime.now();
+    }
 }

--- a/src/main/java/pickRAP/server/domain/scrap/Scrap.java
+++ b/src/main/java/pickRAP/server/domain/scrap/Scrap.java
@@ -32,7 +32,9 @@ public class Scrap extends BaseEntity {
 
     private String fileUrl;
 
-//    private LocalDateTime latestTime;
+    private LocalDateTime revisitTime;
+
+    private Long revisitCount;
 
     @Enumerated(EnumType.STRING)
     private ScrapType scrapType;
@@ -49,12 +51,15 @@ public class Scrap extends BaseEntity {
     private List<ScrapHashtag> scrapHashtags = new ArrayList<>();
 
     @Builder
-    public Scrap(String title, String content, String memo, String fileUrl, ScrapType scrapType) {
+    public Scrap(String title, String content, String memo, String fileUrl, ScrapType scrapType,
+                 LocalDateTime revisitTime, Long revisitCount) {
         this.title = title;
         this.content = content;
         this.memo = memo;
         this.fileUrl = fileUrl;
         this.scrapType = scrapType;
+        this.revisitTime = revisitTime;
+        this.revisitCount = revisitCount;
     }
 
     public void setMember(Member member) {

--- a/src/main/java/pickRAP/server/repository/scrap/ScrapRepositoryCustom.java
+++ b/src/main/java/pickRAP/server/repository/scrap/ScrapRepositoryCustom.java
@@ -2,6 +2,7 @@ package pickRAP.server.repository.scrap;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import pickRAP.server.controller.dto.analysis.RevisitResponse;
 import pickRAP.server.controller.dto.scrap.ScrapFilterCondition;
 import pickRAP.server.controller.dto.scrap.ScrapResponse;
 
@@ -10,4 +11,6 @@ import java.util.List;
 public interface ScrapRepositoryCustom {
 
     Slice<ScrapResponse> filterPageScraps(Long lastScrapId, ScrapFilterCondition scrapFilterCondition, Pageable pageable);
+
+    List<RevisitResponse> findByRevisitTimeAndRevisitCount(String email);
 }

--- a/src/main/java/pickRAP/server/repository/scrap/ScrapRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/scrap/ScrapRepositoryImpl.java
@@ -8,15 +8,20 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.util.StringUtils;
+import pickRAP.server.controller.dto.analysis.QRevisitResponse;
+import pickRAP.server.controller.dto.analysis.RevisitResponse;
 import pickRAP.server.controller.dto.scrap.QScrapResponse;
 import pickRAP.server.controller.dto.scrap.ScrapFilterCondition;
 import pickRAP.server.controller.dto.scrap.ScrapResponse;
+import pickRAP.server.domain.scrap.Scrap;
 import pickRAP.server.domain.scrap.ScrapType;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 
 import static pickRAP.server.domain.category.QCategory.category;
+import static pickRAP.server.domain.member.QMember.member;
 import static pickRAP.server.domain.scrap.QScrap.*;
 import static pickRAP.server.domain.scrap.QScrapHashtag.scrapHashtag;
 
@@ -104,5 +109,24 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom {
         } else {
             return null;
         }
+    }
+
+    @Override
+    public List<RevisitResponse> findByRevisitTimeAndRevisitCount(String email) {
+        // 스크랩 시기가 1개월이 지났고, 방문수가 3회 이하인 콘텐츠
+        return queryFactory
+                .select(new QRevisitResponse(scrap.id))
+                .from(scrap)
+                .join(scrap.member, member)
+                .where(
+                        member.email.eq(email),
+                        scrap.revisitTime.lt(LocalDateTime.now().minusMonths(1)),
+                        scrap.revisitCount.lt(4)
+                        )
+                .orderBy(
+                        scrap.revisitTime.asc(),
+                        scrap.revisitCount.asc()
+                )
+                .fetch();
     }
 }

--- a/src/main/java/pickRAP/server/repository/scrap/ScrapRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/scrap/ScrapRepositoryImpl.java
@@ -115,7 +115,7 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom {
     public List<RevisitResponse> findByRevisitTimeAndRevisitCount(String email) {
         // 스크랩 시기가 1개월이 지났고, 방문수가 3회 이하인 콘텐츠
         return queryFactory
-                .select(new QRevisitResponse(scrap.id))
+                .select(new QRevisitResponse(scrap.id, scrap.title))
                 .from(scrap)
                 .join(scrap.member, member)
                 .where(

--- a/src/main/java/pickRAP/server/service/scrap/RevisitScrapService.java
+++ b/src/main/java/pickRAP/server/service/scrap/RevisitScrapService.java
@@ -1,0 +1,32 @@
+package pickRAP.server.service.scrap;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pickRAP.server.controller.dto.analysis.RevisitResponse;
+import pickRAP.server.repository.scrap.ScrapRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RevisitScrapService {
+    private final ScrapRepository scrapRepository;
+
+    @Transactional
+    public List<RevisitResponse> getRevisitContents(String email, String filter) {
+        List<RevisitResponse> revisitScrapList = scrapRepository.findByRevisitTimeAndRevisitCount(email);
+
+        if(filter.equals("top")) {
+            List<RevisitResponse> top3Contents = new ArrayList<>(3);
+
+            for(int i = 0; i < 3; i++) {
+                top3Contents.add(revisitScrapList.get(i));
+            }
+            return top3Contents;
+        }
+
+        return revisitScrapList;
+    }
+}

--- a/src/main/java/pickRAP/server/service/scrap/ScrapService.java
+++ b/src/main/java/pickRAP/server/service/scrap/ScrapService.java
@@ -89,7 +89,6 @@ public class ScrapService {
 
         if(compareToRevisitDay(scrap.getRevisitTime()) == 1) {
             scrap.updateRevisitRecord();
-            scrapRepository.save(scrap);
         }
 
         return scrapResponse;

--- a/src/main/java/pickRAP/server/service/scrap/ScrapService.java
+++ b/src/main/java/pickRAP/server/service/scrap/ScrapService.java
@@ -94,7 +94,7 @@ public class ScrapService {
         return scrapResponse;
     }
 
-    public int compareToRevisitDay(LocalDateTime lastedRevisitTime) {
+    private int compareToRevisitDay(LocalDateTime lastedRevisitTime) {
         // 일 단위 비교
         lastedRevisitTime = lastedRevisitTime
                 .truncatedTo(ChronoUnit.DAYS);

--- a/src/main/java/pickRAP/server/service/scrap/ScrapService.java
+++ b/src/main/java/pickRAP/server/service/scrap/ScrapService.java
@@ -29,6 +29,7 @@ import pickRAP.server.service.magazine.MagazineService;
 import pickRAP.server.service.text.TextService;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.*;
 
 import static pickRAP.server.util.s3.S3Util.uploadFile;
@@ -307,6 +308,8 @@ public class ScrapService {
                 .content(scrapRequest.getContent())
                 .memo(scrapRequest.getMemo())
                 .scrapType(ScrapType.valueOf(scrapRequest.getScrapType().toUpperCase(Locale.ROOT)))
+                .revisitTime(LocalDateTime.now())
+                .revisitCount(0L)
                 .build();
         scrap.setMember(member);
         scrap.setCategory(category);
@@ -320,6 +323,8 @@ public class ScrapService {
                 .memo(scrapRequest.getMemo())
                 .fileUrl(fileUrl)
                 .scrapType(ScrapType.valueOf(scrapRequest.getScrapType().toUpperCase(Locale.ROOT)))
+                .revisitTime(LocalDateTime.now())
+                .revisitCount(0L)
                 .build();
         scrap.setMember(member);
         scrap.setCategory(category);


### PR DESCRIPTION
## 📮 관련 이슈
- Resolved: #145 

## ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->
- 사용자가 1개월 이내 재방문하지 않았고, 재방문 횟수가 3회 이내인 스크랩 콘텐츠를 제공하는 API를 구현했습니다.
- scrap 테이블에 `revisit_count`를 추가하여 재방문 횟수를 확인했습니다.
- scrap 테이블에 `revisit_time`을 추가하여 재방문 날짜를 확인했습니다.
- 재방문 횟수와 날짜는 API 무한 요청이나 새로고침으로 인한 의미없는 카운트를 방지하고자 같은 날짜의 재방문은 갱신 처리하지 않았습니다. 
```java
public int compareToRevisitDay(LocalDateTime lastedRevisitTime) {
        // 일 단위 비교
        lastedRevisitTime = lastedRevisitTime
                .truncatedTo(ChronoUnit.DAYS);
        LocalDateTime today = LocalDateTime.now()
                .truncatedTo(ChronoUnit.DAYS);

        if(lastedRevisitTime.compareTo(today) != 0) {
            // 재방문 날짜가 오늘이 아니라면
            return 1;
        }
        return 0;
    }
```
## 🌱 PR 포인트
- scrap 데이터베이스 구조 변경
- 같은 api(`/analysis/revisit`)를 filter 구분하여 재활용
- preview 개선 후 response dto 업데이트 필요
- 지난번 main에서 배포 코드를 수정해서 nginx 코드도 함께 PR 날립니다.. 유의하겠습니다😔

## 📸 스크린샷
|스크린샷|
|:--:|
|![image](https://user-images.githubusercontent.com/78305431/215716214-59f705f9-eff9-4d34-82b8-7e2995f67fd6.png)|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
