### PR TITLE
매거진 검색/추천 1번&2번 API 구현

### DIFF
--- a/src/main/java/pickRAP/server/controller/MagazineController.java
+++ b/src/main/java/pickRAP/server/controller/MagazineController.java
@@ -178,9 +178,7 @@ public class MagazineController {
     })
     public ResponseEntity<BaseResponse<List<MagazineListResponse>>> getSearchMagazineList(
             @RequestParam("search_keyword") String keyword) {
-        String email = authService.getUserEmail();
-
-        List<MagazineListResponse> response = magazineService.findMagazineByHashtag(email, keyword);
+        List<MagazineListResponse> response = magazineService.findMagazineByHashtag(keyword);
 
         return ResponseEntity.ok(new BaseResponse(response));
     }

--- a/src/main/java/pickRAP/server/controller/MagazineController.java
+++ b/src/main/java/pickRAP/server/controller/MagazineController.java
@@ -170,4 +170,19 @@ public class MagazineController {
 
         return ResponseEntity.ok(new BaseResponse(result));
     }
+
+    @GetMapping("/magazine/search")
+    @ApiOperation(value = "매거진 검색", notes = "query string에 search_keyword(검색어)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "500", description = "서버 예외")
+    })
+    public ResponseEntity<BaseResponse<List<MagazineListResponse>>> getSearchMagazineList(
+            @RequestParam("search_keyword") String keyword) {
+        String email = authService.getUserEmail();
+
+        List<MagazineListResponse> response = magazineService.findMagazineByHashtag(email, keyword);
+
+        return ResponseEntity.ok(new BaseResponse(response));
+    }
+
 }

--- a/src/main/java/pickRAP/server/repository/hashtag/HashtagRepository.java
+++ b/src/main/java/pickRAP/server/repository/hashtag/HashtagRepository.java
@@ -6,10 +6,13 @@ import org.springframework.data.repository.query.Param;
 import pickRAP.server.domain.hashtag.Hashtag;
 import pickRAP.server.domain.member.Member;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface HashtagRepository extends JpaRepository<Hashtag, Long>, HashtagRepositoryCustom {
 
     @Query("select h from Hashtag h where h.tag = :tag and h.member = :member")
     Optional<Hashtag> findMemberHashtag(@Param("tag") String tag, @Param("member")Member member);
+
+    List<Hashtag> findByMember(Member member);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
@@ -11,5 +11,4 @@ import java.util.Optional;
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
     Optional<Magazine> findByTitleAndMember(String title, Member member);
     Optional<Magazine> findTop3ByMemberOrderByCreateTimeDesc(Member member);
-    List<Magazine> findTop20ByOpenStatusOrderByCreateTimeDesc(boolean openStatus);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
     Optional<Magazine> findByTitleAndMember(String title, Member member);
-    Optional<Magazine> findTop1ByMemberOrderByCreateTimeDesc(Member member);
+    Optional<Magazine> findTop3ByMemberOrderByCreateTimeDesc(Member member);
     List<Magazine> findTop20ByOpenStatusOrderByCreateTimeDesc(boolean openStatus);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
     Optional<Magazine> findByTitleAndMember(String title, Member member);
-    Optional<Magazine> findTop3ByMemberOrderByCreateTimeDesc(Member member);
+    List<Magazine> findTop3ByMemberOrderByCreateTimeDesc(Member member);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
@@ -4,9 +4,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import pickRAP.server.domain.magazine.Magazine;
 import pickRAP.server.domain.member.Member;
 
+import java.util.List;
 import java.util.Optional;
 
 
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
     Optional<Magazine> findByTitleAndMember(String title, Member member);
+    Optional<Magazine> findTop1ByMemberOrderByCreateTimeDesc(Member member);
+    List<Magazine> findTop20ByOpenStatusOrderByCreateTimeDesc(boolean openStatus);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryCustom.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryCustom.java
@@ -6,5 +6,6 @@ import java.util.List;
 
 public interface MagazineRepositoryCustom {
     List<Magazine> findMemberMagazines(String email);
-    List<Magazine> findMagazineByHashtag(String hashtag);
+    List<Magazine> findMagazineByHashtag(String keyword);
+    List<Magazine> findMagazineByHashtagAndNotWriter(List<String> keyword, String email);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryCustom.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryCustom.java
@@ -1,11 +1,10 @@
 package pickRAP.server.repository.magazine;
 
 import pickRAP.server.domain.magazine.Magazine;
-import pickRAP.server.domain.member.Member;
 
 import java.util.List;
 
 public interface MagazineRepositoryCustom {
     List<Magazine> findMemberMagazines(String email);
-
+    List<Magazine> findMagazineByHashtag(String hashtag);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
@@ -7,8 +7,12 @@ import pickRAP.server.domain.magazine.Magazine;
 
 import java.util.List;
 
+import static pickRAP.server.domain.hashtag.QHashtag.hashtag;
 import static pickRAP.server.domain.magazine.QMagazine.magazine;
+import static pickRAP.server.domain.magazine.QMagazinePage.magazinePage;
 import static pickRAP.server.domain.member.QMember.member;
+import static pickRAP.server.domain.scrap.QScrap.scrap;
+import static pickRAP.server.domain.scrap.QScrapHashtag.scrapHashtag;
 
 @RequiredArgsConstructor
 public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
@@ -22,5 +26,24 @@ public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
                 .where(member.email.eq(email))
                 .orderBy(magazine.createTime.desc())
                 .fetch();
+    }
+
+    @Override
+    public List<Magazine> findMagazineByHashtag(String keyword) {
+        // 해시태그 tag 검색
+        // 스크랩 scrap id 검색
+        // 매거진 페이지 magazine id 검색
+        // 매거진 검색
+        return queryFactory
+                .selectFrom(magazine)
+                .join(magazine.pages, magazinePage)
+                .join(magazinePage.scrap, scrap)
+                .join(scrap.scrapHashtags, scrapHashtag)
+                .join(scrapHashtag.hashtag, hashtag)
+                .where(
+                        hashtag.tag.contains(keyword),
+                        magazine.openStatus.eq(true)
+                )
+                .distinct().fetch();
     }
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
@@ -49,7 +49,6 @@ public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
     public List<Magazine> findMagazineByHashtagAndNotWriter(List<String> keyword, String email) {
         BooleanBuilder builder = new BooleanBuilder();
         for(String k : keyword) {
-            System.out.print("잇힝 " + k);
             builder.and(hashtag.tag.contains(k));
         }
         builder.and(magazine.openStatus.eq(true));

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
@@ -49,6 +49,7 @@ public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
     public List<Magazine> findMagazineByHashtagAndNotWriter(List<String> keyword, String email) {
         BooleanBuilder builder = new BooleanBuilder();
         for(String k : keyword) {
+            System.out.print("잇힝 " + k);
             builder.and(hashtag.tag.contains(k));
         }
         builder.and(magazine.openStatus.eq(true));

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
@@ -30,10 +30,6 @@ public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
 
     @Override
     public List<Magazine> findMagazineByHashtag(String keyword) {
-        // 해시태그 tag 검색
-        // 스크랩 scrap id 검색
-        // 매거진 페이지 magazine id 검색
-        // 매거진 검색
         return queryFactory
                 .selectFrom(magazine)
                 .join(magazine.pages, magazinePage)

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
@@ -1,5 +1,7 @@
 package pickRAP.server.repository.magazine;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import pickRAP.server.domain.category.Category;
@@ -42,4 +44,24 @@ public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
                 )
                 .distinct().fetch();
     }
+
+    @Override
+    public List<Magazine> findMagazineByHashtagAndNotWriter(List<String> keyword, String email) {
+        BooleanBuilder builder = new BooleanBuilder();
+        for(String k : keyword) {
+            builder.and(hashtag.tag.contains(k));
+        }
+        builder.and(magazine.openStatus.eq(true));
+        builder.and(magazine.member.email.ne(email));
+
+        return queryFactory
+                .selectFrom(magazine)
+                .join(magazine.pages, magazinePage)
+                .join(magazinePage.scrap, scrap)
+                .join(scrap.scrapHashtags, scrapHashtag)
+                .join(scrapHashtag.hashtag, hashtag)
+                .where(builder)
+                .distinct().fetch();
+    }
+
 }

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -275,13 +275,7 @@ public class MagazineService {
     }
 
     @Transactional
-    public List<MagazineListResponse> findMagazineByHashtag(String email, String hashtag) {
-        Member member = memberRepository.findByEmail(email).orElseThrow();
-
-        // 해시태그 tag 검색
-        // 스크랩 scrap id 검색
-        // 매거진 페이지 magazine id 검색
-        // 매거진 검색
+    public List<MagazineListResponse> findMagazineByHashtag(String hashtag) {
         List<Magazine> findMagazines = magazineRepositoryCustom.findMagazineByHashtag(hashtag);
 
         List<MagazineListResponse> collect = findMagazines.stream()

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -374,9 +374,9 @@ public class MagazineService {
 
         if(findMagazines.size() < RECOMMENDED_MAGAZINE_REMAIN_SIZE) {
             result.addAll(findMagazines);
+            result = magazineDeduplication(result);
         }
         else {
-            isFullSecond = true;
             result.addAll(findMagazines);
             result = magazineDeduplication(result);
 
@@ -433,30 +433,28 @@ public class MagazineService {
 
         // 겹치는 해시태그가 많은 순서
         for(int i = hashtags.size(); i > 0 ; i--) {
-            List<String> priorityHash = combination(hashtags, visited, 0, hashtags.size(), i);
-
-            findMagazines.addAll(
-                    magazineRepositoryCustom.findMagazineByHashtagAndNotWriter(priorityHash, email));
+            findMagazines.addAll(combination(hashtags, visited, 0, hashtags.size(), i, email));
         }
 
         return findMagazines;
     }
 
     // 조합(백트래킹) : 순서 상관없는 경우의 수
-    private List<String> combination(List<String> hashtags, boolean[] visited, int start, int n, int r) {
-        List<String> result = new ArrayList<>();
+    private List<Magazine> combination(List<String> hashtags, boolean[] visited, int start, int n, int r, String email) {
+        List<Magazine> result = new ArrayList<>();
         if(r == 0) {
+            List<String> priorityHashtags = new ArrayList<>();
             for (int i = 0; i < n; i++) {
                 if (visited[i]) {
-                    result.add(hashtags.get(i));
+                    priorityHashtags.add(hashtags.get(i));
                 }
             }
-            return result;
+            return magazineRepositoryCustom.findMagazineByHashtagAndNotWriter(priorityHashtags, email);
         }
 
         for(int i = start; i < n; i++) {
             visited[i] = true;
-            result = combination(hashtags, visited, i + 1, n, r - 1);
+            result.addAll(combination(hashtags, visited, i + 1, n, r - 1, email));
             visited[i] = false;
         }
         return result;

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -23,6 +23,7 @@ import pickRAP.server.repository.magazine.MagazinePageRepository;
 import pickRAP.server.repository.magazine.MagazineRepository;
 import pickRAP.server.repository.magazine.MagazineRepositoryCustom;
 import pickRAP.server.repository.member.MemberRepository;
+import pickRAP.server.repository.scrap.ScrapHashtagRepository;
 import pickRAP.server.repository.scrap.ScrapRepository;
 import pickRAP.server.service.text.TextService;
 
@@ -49,6 +50,7 @@ public class MagazineService {
     private final TextService textService;
     private final ColorRepository colorRepository;
     private final HashtagRepository hashtagRepository;
+    private final ScrapHashtagRepository scrapHashtagRepository;
 
     @Transactional
     public void save(MagazineRequest request, String email) {
@@ -340,7 +342,7 @@ public class MagazineService {
         }
 
         // 1-2. 사용자의 해시태그를 바탕으로 Magazine 찾기
-        findMagazineByHashtagOrderByPriority(findMagazines, hashtags, email);
+        findMagazines = findMagazineByHashtagOrderByPriority(findMagazines, hashtags, email);
 
         if(findMagazines.size() - 1 < RECOMMENDED_MAGAZINE_FIRST_SIZE) {
             result = findMagazines;
@@ -402,7 +404,7 @@ public class MagazineService {
 
             for(MagazinePage page : m.getPages()) {
                 Scrap scrap = page.getScrap();
-                scrapHashtags.addAll(scrap.getScrapHashtags());
+                scrapHashtags.addAll(scrapHashtagRepository.findByScrapId(scrap.getId()));
             }
 
             for(ScrapHashtag scrapHashtag : scrapHashtags) {

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -306,12 +306,12 @@ public class MagazineService {
 
         // 1-1. 사용자의 최근 제작된 3개의 매거진의 해시태그 사용하기
         Member member = memberRepository.findByEmail(email).orElseThrow();
-        Optional<Magazine> latestMagazine = magazineRepository.findTop3ByMemberOrderByCreateTimeDesc(member);
+        List<Magazine> latestMagazine = magazineRepository.findTop3ByMemberOrderByCreateTimeDesc(member);
 
         List<String> hashtags = new ArrayList<>();
         List<Magazine> findMagazines = new ArrayList<>();
 
-        if (!latestMagazine.isPresent()) {
+        if (latestMagazine.size() == 0) {
             // 사용자의 매거진 제작 이력이 없다면 스크랩 해시태그 기준 추천
             List<Hashtag> findHashtags = hashtagRepository.findByMember(member);
 
@@ -336,7 +336,7 @@ public class MagazineService {
         }
         else {
             // 1-2. 사용자의 해시태그 String 리스트를 먼저 찾기
-            hashtags = getMagazineHashtags(latestMagazine.get());
+            hashtags = getMagazineHashtags(latestMagazine);
         }
 
         // 1-2. 사용자의 해시태그를 바탕으로 Magazine 찾기
@@ -394,17 +394,20 @@ public class MagazineService {
     }
 
     // 매거진의 모든 해시태그를 반환
-    private List<String> getMagazineHashtags(Magazine magazine) {
-        List<ScrapHashtag> scrapHashtags = new ArrayList<>();
+    private List<String> getMagazineHashtags(List<Magazine> magazine) {
         List<String> hashtags = new ArrayList<>();
 
-        for(MagazinePage page : magazine.getPages()) {
-            Scrap scrap = page.getScrap();
-            scrapHashtags.addAll(scrap.getScrapHashtags());
-        }
+        for(Magazine m : magazine) {
+            List<ScrapHashtag> scrapHashtags = new ArrayList<>();
 
-        for(ScrapHashtag scrapHashtag : scrapHashtags) {
-            hashtags.add(scrapHashtag.getHashtag().getTag());
+            for(MagazinePage page : m.getPages()) {
+                Scrap scrap = page.getScrap();
+                scrapHashtags.addAll(scrap.getScrapHashtags());
+            }
+
+            for(ScrapHashtag scrapHashtag : scrapHashtags) {
+                hashtags.add(scrapHashtag.getHashtag().getTag());
+            }
         }
         return hashtags;
     }

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -273,4 +273,25 @@ public class MagazineService {
             findColor.get().updateColor(colorType);
         }
     }
+
+    @Transactional
+    public List<MagazineListResponse> findMagazineByHashtag(String email, String hashtag) {
+        Member member = memberRepository.findByEmail(email).orElseThrow();
+
+        // 해시태그 tag 검색
+        // 스크랩 scrap id 검색
+        // 매거진 페이지 magazine id 검색
+        // 매거진 검색
+        List<Magazine> findMagazines = magazineRepositoryCustom.findMagazineByHashtag(hashtag);
+
+        List<MagazineListResponse> collect = findMagazines.stream()
+                .map(m -> MagazineListResponse.builder()
+                        .magazineId(m.getId())
+                        .coverUrl(m.getCover())
+                        .title(m.getTitle())
+                        .build())
+                .collect(Collectors.toList());
+
+        return collect;
+    }
 }

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -317,9 +317,9 @@ public class MagazineService {
         // 최종 추천 매거진을 수집
         List<Magazine> result = new ArrayList<>();
 
-        // 1-1. +) 사용자의 최근 제작된 매거진의 해시태그 사용하기
+        // 1-1. +) 사용자의 최근 제작된 3개의 매거진의 해시태그 사용하기
         Member member = memberRepository.findByEmail(email).orElseThrow();
-        Optional<Magazine> latestMagazine = magazineRepository.findTop1ByMemberOrderByCreateTimeDesc(member);
+        Optional<Magazine> latestMagazine = magazineRepository.findTop3ByMemberOrderByCreateTimeDesc(member);
 
         List<Magazine> findMagazines = new ArrayList<>();
         if (!latestMagazine.isPresent()) {

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -363,8 +363,9 @@ public class MagazineService {
         List<HashTagResponse> hashTagResponses = hashtagRepository.getHashtagAnalysisResults(hashtagFilterCond, email);
 
         hashtags = new ArrayList<>();
-        for(HashTagResponse hashtag : hashTagResponses) {
-            hashtags.add(hashtag.getTag());
+        // '기타' 태그 제외
+        for(int i = 0; i < 3; i++) {
+            hashtags.add(hashTagResponses.get(i).getTag());
         }
 
         // 2-2. 사용자의 해시태그를 바탕으로 Magazine 찾기
@@ -432,8 +433,10 @@ public class MagazineService {
 
         // 겹치는 해시태그가 많은 순서
         for(int i = hashtags.size(); i > 0 ; i--) {
-            List<String> searchHashtags = combination(hashtags, visited, 0, hashtags.size(), i);
-            findMagazines.addAll(magazineRepositoryCustom.findMagazineByHashtagAndNotWriter(searchHashtags, email));
+            List<String> priorityHash = combination(hashtags, visited, 0, hashtags.size(), i);
+
+            findMagazines.addAll(
+                    magazineRepositoryCustom.findMagazineByHashtagAndNotWriter(priorityHash, email));
         }
 
         return findMagazines;
@@ -443,20 +446,17 @@ public class MagazineService {
     private List<String> combination(List<String> hashtags, boolean[] visited, int start, int n, int r) {
         List<String> result = new ArrayList<>();
         if(r == 0) {
-            System.out.print("해시태그 종류 : ");
             for (int i = 0; i < n; i++) {
                 if (visited[i]) {
                     result.add(hashtags.get(i));
-                    System.out.print(hashtags.get(i) + ", ");
                 }
             }
-            System.out.println();
             return result;
         }
 
         for(int i = start; i < n; i++) {
             visited[i] = true;
-            combination(hashtags, visited, i + 1, n, r - 1);
+            result = combination(hashtags, visited, i + 1, n, r - 1);
             visited[i] = false;
         }
         return result;

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pickRAP.server.common.BaseException;
 import pickRAP.server.common.BaseExceptionStatus;
+import pickRAP.server.controller.dto.analysis.HashTagResponse;
+import pickRAP.server.controller.dto.analysis.HashtagFilterCondition;
 import pickRAP.server.controller.dto.magazine.*;
 import pickRAP.server.domain.magazine.Color;
 import pickRAP.server.domain.magazine.ColorType;
@@ -12,8 +14,10 @@ import pickRAP.server.domain.magazine.Magazine;
 import pickRAP.server.domain.magazine.MagazinePage;
 import pickRAP.server.domain.member.Member;
 import pickRAP.server.domain.scrap.Scrap;
+import pickRAP.server.domain.scrap.ScrapHashtag;
 import pickRAP.server.domain.scrap.ScrapType;
 import pickRAP.server.repository.color.ColorRepository;
+import pickRAP.server.repository.hashtag.HashtagRepository;
 import pickRAP.server.repository.magazine.MagazinePageRepository;
 import pickRAP.server.repository.magazine.MagazineRepository;
 import pickRAP.server.repository.magazine.MagazineRepositoryCustom;
@@ -21,9 +25,7 @@ import pickRAP.server.repository.member.MemberRepository;
 import pickRAP.server.repository.scrap.ScrapRepository;
 import pickRAP.server.service.text.TextService;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static pickRAP.server.common.BaseExceptionStatus.*;
@@ -35,6 +37,9 @@ public class MagazineService {
     final static int MAX_TEXT_LENGTH = 200;
     final static int MAX_TITLE_LENGTH = 15;
 
+    final static int RECOMMENDED_MAGAZINE_FIRST_SIZE = 8;
+    final static int RECOMMENDED_MAGAZINE_REMAIN_SIZE = 6;
+
     private final MemberRepository memberRepository;
     private final MagazineRepository magazineRepository;
     private final MagazineRepositoryCustom magazineRepositoryCustom;
@@ -42,6 +47,7 @@ public class MagazineService {
     private final ScrapRepository scrapRepository;
     private final TextService textService;
     private final ColorRepository colorRepository;
+    private final HashtagRepository hashtagRepository;
 
     @Transactional
     public void save(MagazineRequest request, String email) {
@@ -287,5 +293,133 @@ public class MagazineService {
                 .collect(Collectors.toList());
 
         return collect;
+    }
+
+    @Transactional
+    public List<MagazineListResponse> recommendedMagazineByMember(String email) {
+      /*
+      추천 로직
+      ** 피드에 보이는 위치와 순서는 랜덤
+      ** 중복 콘텐츠 우선순위 3>2>1
+
+      1. 동일한 해시태그가 사용된 매거진 (40%) - 8개
+      동일 해시태그 개수가 많은 순서대로 우선 추천
+
+      2. 사용자의 TOP3 해시태그 사용된 매거진 (30%) - 6개
+      더 많은 개수의 TOP3 해시태그를 사용한 순서대로 우선 추천
+
+      3. 사용자의 TOP3 해시태그와 연관됐지만 매거진에서는 사용되지 않은 경우 (30%) - 6개
+       */
+
+        // 기준별 콘텐츠가 비율만큼 서치되었는지 여부
+        boolean isFullFirst = false, isFullSecond = false, isFullThird = false;
+
+        // 최종 추천 매거진을 수집
+        List<Magazine> result = new ArrayList<>();
+
+        // 1-1. +) 사용자의 최근 제작된 매거진의 해시태그 사용하기
+        Member member = memberRepository.findByEmail(email).orElseThrow();
+        Optional<Magazine> latestMagazine = magazineRepository.findTop1ByMemberOrderByCreateTimeDesc(member);
+
+        List<Magazine> findMagazines = new ArrayList<>();
+        if (!latestMagazine.isPresent()) {
+            // +) 사용자의 매거진 제작 이력이 없다면 전체 매거진에서 최근 20개 랜덤 추천
+            findMagazines = magazineRepository.findTop20ByOpenStatusOrderByCreateTimeDesc(true);
+        } else {
+            // 1-2. 사용자의 해시태그 String 리스트를 먼저 찾기
+            List<String> hashtags = getMagazineHashtags(latestMagazine.get());
+
+            // 1-2. 사용자의 해시태그를 바탕으로 Magazine 찾기
+            findMagazineByHashtagOrderByPriority(findMagazines, hashtags, email);
+
+            // 검색한 매거진의 크기가 8개보다 적다면
+            if(findMagazines.size() < RECOMMENDED_MAGAZINE_FIRST_SIZE + 1) {
+                result = findMagazines;
+            } else {
+                isFullFirst = true;
+                result = findMagazines.subList(0, RECOMMENDED_MAGAZINE_FIRST_SIZE);
+            }
+
+            // 2-1. 사용자의 TOP3 해시태그 String 리스트를 먼저 찾기 - 이전에 사용한 해시태그 분석 로직 재사용
+            HashtagFilterCondition hashtagFilterCond = HashtagFilterCondition.builder()
+                    .filter("all")
+                    .build();
+
+            List<HashTagResponse> hashTagResponses = hashtagRepository.getHashtagAnalysisResults(hashtagFilterCond, email);
+
+            hashtags = new ArrayList<>();
+            for(HashTagResponse hashtag : hashTagResponses) {
+                hashtags.add(hashtag.getTag());
+            }
+
+            // 2-2. 사용자의 해시태그를 바탕으로 Magazine 찾기
+            findMagazineByHashtagOrderByPriority(findMagazines, hashtags, email);
+
+            // 검색한 매거진의 크기가 6개보다 적다면
+            if(findMagazines.size() < RECOMMENDED_MAGAZINE_REMAIN_SIZE + 1) {
+                result.addAll(findMagazines);
+            } else {
+                // 2번 기준으로 찾은 매거진 6개
+                isFullSecond = true;
+                result.addAll(findMagazines.subList(0, RECOMMENDED_MAGAZINE_REMAIN_SIZE));
+
+                // 1번 기준으로 찾은 매거진의 개수가 모자랐다면
+                if(!isFullFirst) {
+                    // 2번 기준으로 찾은 매거진으로 채우기
+                    int remainIndex = RECOMMENDED_MAGAZINE_FIRST_SIZE - result.size();
+                    for(int i = 0, j = RECOMMENDED_MAGAZINE_REMAIN_SIZE;
+                        i < remainIndex && j < findMagazines.size(); i++, j++) {
+                        result.add(findMagazines.get(j));
+                    }
+                }
+            }
+
+            // 3. 사용자의 TOP3 해시태그와 연관됐지만 매거진에서는 사용되지 않은 경우 (30%) - 6개
+
+        }
+        List<MagazineListResponse> collect = result.stream()
+                .map(m -> MagazineListResponse.builder()
+                        .magazineId(m.getId())
+                        .coverUrl(m.getCover())
+                        .title(m.getTitle())
+                        .build())
+                .collect(Collectors.toList());
+
+        return collect;
+    }
+
+    // 매거진의 모든 해시태그를 반환
+    private List<String> getMagazineHashtags(Magazine magazine) {
+        List<ScrapHashtag> scrapHashtags = new ArrayList<>();
+        List<String> hashtags = new ArrayList<>();
+
+        for(MagazinePage page : magazine.getPages()) {
+            Scrap scrap = page.getScrap();
+            scrapHashtags.addAll(scrap.getScrapHashtags());
+        }
+
+        for(ScrapHashtag scrapHashtag : scrapHashtags) {
+            hashtags.add(scrapHashtag.getHashtag().getTag());
+        }
+        return hashtags;
+    }
+
+    // List 중복 제거 (List->Set->List)
+    // 후순위로 삽입된 중복데이터가 삭제됨
+    private List<Magazine> removeMagazineDuplication(List<Magazine> magazines) {
+        return new ArrayList<Magazine>(
+                new HashSet<Magazine>(magazines));
+    }
+
+    // 해시태그로 매거진 찾기 (우선순위)
+    private List<Magazine> findMagazineByHashtagOrderByPriority(List<Magazine> findMagazines,
+                                                             List<String> hashtags, String email) {
+        // 겹치는 해시태그가 많은 순서
+        for(int i = hashtags.size()-1; i >= 0; i--) {
+            findMagazines = magazineRepositoryCustom.findMagazineByHashtagAndNotWriter(hashtags, email);
+            hashtags.remove(i);
+        }
+        // 중복 데이터 삭제
+        return removeMagazineDuplication(findMagazines);
     }
 }

--- a/src/main/java/pickRAP/server/util/deduplication/DeduplicationUtils.java
+++ b/src/main/java/pickRAP/server/util/deduplication/DeduplicationUtils.java
@@ -1,0 +1,30 @@
+package pickRAP.server.util.deduplication;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class DeduplicationUtils {
+    //Object 중복 제거
+    public static <T> List<T> deduplication(final List<T> list, Function<? super T,?> key){
+        return list.stream()
+                .filter(deduplication(key))
+                .collect(Collectors.toList());
+    }
+
+   private static <T> Predicate<T> deduplication(Function<? super T,?>key) {
+        final Set<Object> set = ConcurrentHashMap.newKeySet();
+        return predicate -> set.add(key.apply(predicate));
+    }
+
+    // String 중복 제거
+    public static List<String> deduplication(List<String> list){
+        return new ArrayList<String>(
+                new HashSet<String>(list));
+    }
+}

--- a/src/test/java/pickRAP/server/magazine/MagazineServiceTest.java
+++ b/src/test/java/pickRAP/server/magazine/MagazineServiceTest.java
@@ -369,15 +369,7 @@ public class MagazineServiceTest {
         List<MagazineListResponse> response = magazineService.recommendedMagazineByMember("member1@test.com");
 
         // then
-        //assertThat(response.size()).isEqualTo(5);
-
-        for(MagazineListResponse r : response) {
-            System.out.println(r.getTitle());
-        }
-//        assertThat(response.get(0).getTitle()).isEqualTo("3개 매거진");
-//        assertThat(response.get(1).getTitle()).isEqualTo("2개 매거진");
-//        assertThat(response.get(2).getTitle()).isEqualTo("3개 매거진");
-//        assertThat(response.get(3).getTitle()).isEqualTo("1개 매거진");
+        assertThat(response.size()).isEqualTo(3);
     }
 
     @Test

--- a/src/test/java/pickRAP/server/magazine/MagazineServiceTest.java
+++ b/src/test/java/pickRAP/server/magazine/MagazineServiceTest.java
@@ -212,7 +212,7 @@ public class MagazineServiceTest {
 
         // 2: 매거진 대량 양산용 멤버
         member = memberRepository.findByEmail("member2@test.com").get();
-        // 2-1) TOP3 설정
+        // 2-1) 3개 일치
         Category category1 = categoryRepository.findMemberCategory("top3", member.getEmail()).get();
 
         scrapService.save(scrapRequest(category1.getId(), "IT", "개발", "백엔드"), null, member.getEmail());
@@ -229,7 +229,7 @@ public class MagazineServiceTest {
 
         magazineService.save(magazineRequest, member.getEmail());
 
-        // 2-2) 최근 매거진 해시태그
+        // 2-2) 1개 일치
         Category category2 = categoryRepository.findMemberCategory("latest", member.getEmail()).get();
 
         scrapService.save(scrapRequest(category2.getId(), "맛집", "무관한", "해시태그"), null, member.getEmail());
@@ -244,7 +244,7 @@ public class MagazineServiceTest {
 
         magazineService.save(magazineRequest, member.getEmail());
 
-        // 2-2) 최근 매거진 해시태그 (우선순위 더 높음)
+        // 2-2) 2개 일치
         scrapService.save(scrapRequest(category2.getId(), "맛집", "IT", "해시태그"), null, member.getEmail());
         coverId = saveCover(member, category2, "2개 매거진");
 
@@ -366,10 +366,24 @@ public class MagazineServiceTest {
         // given
 
         // when
-        List<MagazineListResponse> response = magazineService.recommendedMagazineByMember("member1@test.com");
+        List<MagazineListResponse> recommendedMagazines = magazineService.recommendedMagazineByMember("member1@test.com");
 
         // then
-        assertThat(response.size()).isEqualTo(3);
+        assertThat(recommendedMagazines.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("매거진 검색")
+    void searchMagazineTest() {
+        // given
+        String keyword = "완전";
+
+        // when
+        List<MagazineListResponse> searchMagazines = magazineService.findMagazineByHashtag(keyword);
+
+        // then
+        assertThat(searchMagazines.size()).isEqualTo(1);
+        assertThat(searchMagazines.get(0).getTitle()).isEqualTo("무관 매거진");
     }
 
     @Test


### PR DESCRIPTION
## 📮 관련 이슈
- Resolved: #150 

## ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->
- 매거진 검색 API 구현 및 테스트
- 매거진 추천 API 추천 정책 1번&2번 구현 및 테스트


## 🌱 PR 포인트
- 코드 가독성이.. 심각하게 안 좋을 수 있음. 따끔한 코드리뷰를 기대중
- 매거진 추천 기능의 특성상, 다량의 매거진 데이터가 필요한데 이를 테스트코드에서 어떻게 세팅하면 좋을지 고민이 큼. 현재는 4개의 매거진 데이터로만 테스트 코드를 작성해놓음. 이에 대해서도 많은 조언을 기대중

- 해시태그가 많이 겹치는 우선순위 정책에 따라 조합 로직을 추가함.
- 중복이 가능한 해시태그의 특성을 고려하여 중복 제거 Util을 추가함.

- 코드 통합 이후 퍼스널 무드를 활용한 기능 구현 예정 (하단 TODO 참고) 
- TODO : 피크랩 초기 사용자에 대응하는 매거진 추천 로직 작성
- TODO : 매거진 3번 추천 정책 구현
- TODO : 예외 처리 (메소드화 작업하며 추가 필요)

## 📸 스크린샷
|스크린샷|
|:--:|
|<img width="342" alt="image" src="https://user-images.githubusercontent.com/78305431/220414734-5625d9ac-f950-4b3e-a409-1ff066974c9c.png">|
|<img width="406" alt="image" src="https://user-images.githubusercontent.com/78305431/220414929-d1c2fd1d-22d3-4fb2-9449-52bf80b3a607.png">|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
- 조합 알고리즘 : https://bcp0109.tistory.com/15
- String List 중복 제거 : https://hianna.tistory.com/582