### PR TITLE
매거진 검색/추천 API 구현

### DIFF
--- a/src/main/java/pickRAP/server/controller/MagazineController.java
+++ b/src/main/java/pickRAP/server/controller/MagazineController.java
@@ -178,9 +178,7 @@ public class MagazineController {
     })
     public ResponseEntity<BaseResponse<List<MagazineListResponse>>> getSearchMagazineList(
             @RequestParam("search_keyword") String keyword) {
-        String email = authService.getUserEmail();
-
-        List<MagazineListResponse> response = magazineService.findMagazineByHashtag(email, keyword);
+        List<MagazineListResponse> response = magazineService.findMagazineByHashtag(keyword);
 
         return ResponseEntity.ok(new BaseResponse(response));
     }

--- a/src/main/java/pickRAP/server/controller/MagazineController.java
+++ b/src/main/java/pickRAP/server/controller/MagazineController.java
@@ -183,4 +183,16 @@ public class MagazineController {
         return ResponseEntity.ok(new BaseResponse(response));
     }
 
+    @GetMapping("/magazine/recommend")
+    @ApiOperation(value = "매거진 추천", notes = "최대 20개의 매거진 추천")
+    @ApiResponses({
+            @ApiResponse(responseCode = "500", description = "서버 예외")
+    })
+    public ResponseEntity<BaseResponse<List<MagazineListResponse>>> getRecommendedMagazineList() {
+        String email = authService.getUserEmail();
+        List<MagazineListResponse> response = magazineService.recommendedMagazineByMember(email);
+
+        return ResponseEntity.ok(new BaseResponse(response));
+    }
+
 }

--- a/src/main/java/pickRAP/server/controller/MagazineController.java
+++ b/src/main/java/pickRAP/server/controller/MagazineController.java
@@ -170,4 +170,19 @@ public class MagazineController {
 
         return ResponseEntity.ok(new BaseResponse(result));
     }
+
+    @GetMapping("/magazine/search")
+    @ApiOperation(value = "매거진 검색", notes = "query string에 search_keyword(검색어)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "500", description = "서버 예외")
+    })
+    public ResponseEntity<BaseResponse<List<MagazineListResponse>>> getSearchMagazineList(
+            @RequestParam("search_keyword") String keyword) {
+        String email = authService.getUserEmail();
+
+        List<MagazineListResponse> response = magazineService.findMagazineByHashtag(email, keyword);
+
+        return ResponseEntity.ok(new BaseResponse(response));
+    }
+
 }

--- a/src/main/java/pickRAP/server/controller/dto/magazine/MagazineListResponse.java
+++ b/src/main/java/pickRAP/server/controller/dto/magazine/MagazineListResponse.java
@@ -1,9 +1,8 @@
 package pickRAP.server.controller.dto.magazine;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
 import lombok.Data;
-import pickRAP.server.domain.magazine.MagazinePage;
+import pickRAP.server.domain.magazine.Magazine;
 
 @Data
 public class MagazineListResponse {
@@ -13,10 +12,9 @@ public class MagazineListResponse {
     private String coverUrl;
     private String title;
 
-    @Builder
-    public MagazineListResponse(Long magazineId, String coverUrl, String title) {
-        this.magazineId = magazineId;
-        this.coverUrl = coverUrl;
-        this.title = title;
+    public MagazineListResponse(Magazine magazine) {
+        this.magazineId = magazine.getId();
+        this.coverUrl = magazine.getCover();
+        this.title = magazine.getTitle();
     }
 }

--- a/src/main/java/pickRAP/server/repository/color/ColorRepositoryCustom.java
+++ b/src/main/java/pickRAP/server/repository/color/ColorRepositoryCustom.java
@@ -13,4 +13,5 @@ public interface ColorRepositoryCustom {
 
     List<PersonalMoodResponse> getPersonalMoodAnalysisResults(Member member);
 
+    List<Magazine> findTop20MagazineByColor();
 }

--- a/src/main/java/pickRAP/server/repository/color/ColorRepositoryCustom.java
+++ b/src/main/java/pickRAP/server/repository/color/ColorRepositoryCustom.java
@@ -15,4 +15,6 @@ public interface ColorRepositoryCustom {
 
     List<Magazine> findTop20MagazinesByColor();
 
+    Magazine findMagazineByColor(ColorType colorType);
+
 }

--- a/src/main/java/pickRAP/server/repository/color/ColorRepositoryCustom.java
+++ b/src/main/java/pickRAP/server/repository/color/ColorRepositoryCustom.java
@@ -13,5 +13,6 @@ public interface ColorRepositoryCustom {
 
     List<PersonalMoodResponse> getPersonalMoodAnalysisResults(Member member);
 
-    List<Magazine> findTop20MagazineByColor();
+    List<Magazine> findTop20MagazinesByColor();
+
 }

--- a/src/main/java/pickRAP/server/repository/color/ColorRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/color/ColorRepositoryImpl.java
@@ -82,7 +82,9 @@ public class ColorRepositoryImpl implements ColorRepositoryCustom{
     public List<Magazine> findTop20MagazinesByColor() {
         return jpaQueryFactory
                 .select(magazine)
-                .innerJoin(magazine.colors, color)
+                .from(magazine)
+                .innerJoin(color)
+                .on(magazine.eq(color.magazine))
                 .groupBy(magazine.id)
                 .orderBy(color.count().desc())
                 .limit(20)

--- a/src/main/java/pickRAP/server/repository/color/ColorRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/color/ColorRepositoryImpl.java
@@ -89,4 +89,15 @@ public class ColorRepositoryImpl implements ColorRepositoryCustom{
                 .fetch();
     }
 
+    @Override
+    public Magazine findMagazineByColor(ColorType colorType) {
+        return jpaQueryFactory
+                .select(magazine)
+                .innerJoin(magazine.colors, color)
+                .where(color.colorType.eq(colorType))
+                .groupBy(magazine.id)
+                .orderBy(color.count().desc())
+                .fetchFirst();
+    }
+
 }

--- a/src/main/java/pickRAP/server/repository/color/ColorRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/color/ColorRepositoryImpl.java
@@ -78,6 +78,15 @@ public class ColorRepositoryImpl implements ColorRepositoryCustom{
         return personalMoodResponses;
     }
 
-
+    @Override
+    public List<Magazine> findTop20MagazineByColor() {
+        return jpaQueryFactory
+                .select(magazine)
+                .innerJoin(magazine.colors, color)
+                .groupBy(magazine.id)
+                .orderBy(color.count().desc())
+                .limit(20)
+                .fetch();
+    }
 
 }

--- a/src/main/java/pickRAP/server/repository/color/ColorRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/color/ColorRepositoryImpl.java
@@ -95,7 +95,9 @@ public class ColorRepositoryImpl implements ColorRepositoryCustom{
     public Magazine findMagazineByColor(ColorType colorType) {
         return jpaQueryFactory
                 .select(magazine)
-                .innerJoin(magazine.colors, color)
+                .from(magazine)
+                .innerJoin(color)
+                .on(magazine.eq(color.magazine))
                 .where(color.colorType.eq(colorType))
                 .groupBy(magazine.id)
                 .orderBy(color.count().desc())

--- a/src/main/java/pickRAP/server/repository/color/ColorRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/color/ColorRepositoryImpl.java
@@ -79,7 +79,7 @@ public class ColorRepositoryImpl implements ColorRepositoryCustom{
     }
 
     @Override
-    public List<Magazine> findTop20MagazineByColor() {
+    public List<Magazine> findTop20MagazinesByColor() {
         return jpaQueryFactory
                 .select(magazine)
                 .innerJoin(magazine.colors, color)

--- a/src/main/java/pickRAP/server/repository/hashtag/HashtagRepository.java
+++ b/src/main/java/pickRAP/server/repository/hashtag/HashtagRepository.java
@@ -6,10 +6,13 @@ import org.springframework.data.repository.query.Param;
 import pickRAP.server.domain.hashtag.Hashtag;
 import pickRAP.server.domain.member.Member;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface HashtagRepository extends JpaRepository<Hashtag, Long>, HashtagRepositoryCustom {
 
     @Query("select h from Hashtag h where h.tag = :tag and h.member = :member")
     Optional<Hashtag> findMemberHashtag(@Param("tag") String tag, @Param("member")Member member);
+
+    List<Hashtag> findByMember(Member member);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 
-public interface MagazineRepository extends JpaRepository<Magazine, Long> {
+public interface MagazineRepository extends JpaRepository<Magazine, Long>, MagazineRepositoryCustom{
     Optional<Magazine> findByTitleAndMember(String title, Member member);
     List<Magazine> findTop3ByMemberOrderByCreateTimeDesc(Member member);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
@@ -11,5 +11,4 @@ import java.util.Optional;
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
     Optional<Magazine> findByTitleAndMember(String title, Member member);
     Optional<Magazine> findTop3ByMemberOrderByCreateTimeDesc(Member member);
-    List<Magazine> findTop20ByOpenStatusOrderByCreateTimeDesc(boolean openStatus);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
@@ -1,5 +1,6 @@
 package pickRAP.server.repository.magazine;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import pickRAP.server.domain.magazine.Magazine;
 import pickRAP.server.domain.member.Member;
@@ -10,5 +11,7 @@ import java.util.Optional;
 
 public interface MagazineRepository extends JpaRepository<Magazine, Long>, MagazineRepositoryCustom{
     Optional<Magazine> findByTitleAndMember(String title, Member member);
+
+    @EntityGraph(attributePaths = {"pages", "pages.scrap"})
     List<Magazine> findTop3ByMemberOrderByCreateTimeDesc(Member member);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
     Optional<Magazine> findByTitleAndMember(String title, Member member);
-    Optional<Magazine> findTop1ByMemberOrderByCreateTimeDesc(Member member);
+    Optional<Magazine> findTop3ByMemberOrderByCreateTimeDesc(Member member);
     List<Magazine> findTop20ByOpenStatusOrderByCreateTimeDesc(boolean openStatus);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
     Optional<Magazine> findByTitleAndMember(String title, Member member);
-    Optional<Magazine> findTop3ByMemberOrderByCreateTimeDesc(Member member);
+    List<Magazine> findTop3ByMemberOrderByCreateTimeDesc(Member member);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepository.java
@@ -4,9 +4,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import pickRAP.server.domain.magazine.Magazine;
 import pickRAP.server.domain.member.Member;
 
+import java.util.List;
 import java.util.Optional;
 
 
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
     Optional<Magazine> findByTitleAndMember(String title, Member member);
+    Optional<Magazine> findTop1ByMemberOrderByCreateTimeDesc(Member member);
+    List<Magazine> findTop20ByOpenStatusOrderByCreateTimeDesc(boolean openStatus);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryCustom.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryCustom.java
@@ -6,5 +6,6 @@ import java.util.List;
 
 public interface MagazineRepositoryCustom {
     List<Magazine> findMemberMagazines(String email);
-    List<Magazine> findMagazineByHashtag(String hashtag);
+    List<Magazine> findMagazineByHashtag(String keyword);
+    List<Magazine> findMagazineByHashtagAndNotWriter(List<String> keyword, String email);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryCustom.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryCustom.java
@@ -1,12 +1,16 @@
 package pickRAP.server.repository.magazine;
 
 import pickRAP.server.domain.magazine.Magazine;
+import pickRAP.server.domain.member.Member;
 
 import java.util.List;
 
 public interface MagazineRepositoryCustom {
     List<Magazine> findMemberMagazines(String email);
+
     List<Magazine> findMagazineByHashtag(String keyword);
+
     List<Magazine> findMagazineByHashtagAndNotWriter(List<String> keyword, String email);
 
+    List<Magazine> findMagazinesColorByMember(Member member);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryCustom.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryCustom.java
@@ -8,6 +8,5 @@ public interface MagazineRepositoryCustom {
     List<Magazine> findMemberMagazines(String email);
     List<Magazine> findMagazineByHashtag(String keyword);
     List<Magazine> findMagazineByHashtagAndNotWriter(List<String> keyword, String email);
-    List<Magazine> findTop20MagazineByColor();
 
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryCustom.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryCustom.java
@@ -8,4 +8,6 @@ public interface MagazineRepositoryCustom {
     List<Magazine> findMemberMagazines(String email);
     List<Magazine> findMagazineByHashtag(String keyword);
     List<Magazine> findMagazineByHashtagAndNotWriter(List<String> keyword, String email);
+    List<Magazine> findTop20MagazineByColor();
+
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryCustom.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryCustom.java
@@ -1,11 +1,10 @@
 package pickRAP.server.repository.magazine;
 
 import pickRAP.server.domain.magazine.Magazine;
-import pickRAP.server.domain.member.Member;
 
 import java.util.List;
 
 public interface MagazineRepositoryCustom {
     List<Magazine> findMemberMagazines(String email);
-
+    List<Magazine> findMagazineByHashtag(String hashtag);
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
@@ -7,8 +7,12 @@ import pickRAP.server.domain.magazine.Magazine;
 
 import java.util.List;
 
+import static pickRAP.server.domain.hashtag.QHashtag.hashtag;
 import static pickRAP.server.domain.magazine.QMagazine.magazine;
+import static pickRAP.server.domain.magazine.QMagazinePage.magazinePage;
 import static pickRAP.server.domain.member.QMember.member;
+import static pickRAP.server.domain.scrap.QScrap.scrap;
+import static pickRAP.server.domain.scrap.QScrapHashtag.scrapHashtag;
 
 @RequiredArgsConstructor
 public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
@@ -22,5 +26,24 @@ public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
                 .where(member.email.eq(email))
                 .orderBy(magazine.createTime.desc())
                 .fetch();
+    }
+
+    @Override
+    public List<Magazine> findMagazineByHashtag(String keyword) {
+        // 해시태그 tag 검색
+        // 스크랩 scrap id 검색
+        // 매거진 페이지 magazine id 검색
+        // 매거진 검색
+        return queryFactory
+                .selectFrom(magazine)
+                .join(magazine.pages, magazinePage)
+                .join(magazinePage.scrap, scrap)
+                .join(scrap.scrapHashtags, scrapHashtag)
+                .join(scrapHashtag.hashtag, hashtag)
+                .where(
+                        hashtag.tag.contains(keyword),
+                        magazine.openStatus.eq(true)
+                )
+                .distinct().fetch();
     }
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
@@ -1,15 +1,14 @@
 package pickRAP.server.repository.magazine;
 
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import pickRAP.server.domain.category.Category;
 import pickRAP.server.domain.magazine.Magazine;
 
 import java.util.List;
 
 import static pickRAP.server.domain.hashtag.QHashtag.hashtag;
+import static pickRAP.server.domain.magazine.QColor.color;
 import static pickRAP.server.domain.magazine.QMagazine.magazine;
 import static pickRAP.server.domain.magazine.QMagazinePage.magazinePage;
 import static pickRAP.server.domain.member.QMember.member;
@@ -62,6 +61,17 @@ public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
                 .join(scrapHashtag.hashtag, hashtag)
                 .where(builder)
                 .distinct().fetch();
+    }
+
+    @Override
+    public List<Magazine> findTop20MagazineByColor() {
+        return queryFactory
+                .select(magazine)
+                .innerJoin(magazine.colors, color)
+                .groupBy(magazine.id)
+                .orderBy(color.count().desc())
+                .limit(20)
+                .fetch();
     }
 
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
@@ -49,7 +49,6 @@ public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
     public List<Magazine> findMagazineByHashtagAndNotWriter(List<String> keyword, String email) {
         BooleanBuilder builder = new BooleanBuilder();
         for(String k : keyword) {
-            System.out.print("잇힝 " + k);
             builder.and(hashtag.tag.contains(k));
         }
         builder.and(magazine.openStatus.eq(true));

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
@@ -49,6 +49,7 @@ public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
     public List<Magazine> findMagazineByHashtagAndNotWriter(List<String> keyword, String email) {
         BooleanBuilder builder = new BooleanBuilder();
         for(String k : keyword) {
+            System.out.print("잇힝 " + k);
             builder.and(hashtag.tag.contains(k));
         }
         builder.and(magazine.openStatus.eq(true));

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
@@ -30,10 +30,6 @@ public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
 
     @Override
     public List<Magazine> findMagazineByHashtag(String keyword) {
-        // 해시태그 tag 검색
-        // 스크랩 scrap id 검색
-        // 매거진 페이지 magazine id 검색
-        // 매거진 검색
         return queryFactory
                 .selectFrom(magazine)
                 .join(magazine.pages, magazinePage)

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
@@ -4,10 +4,12 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import pickRAP.server.domain.magazine.Magazine;
+import pickRAP.server.domain.member.Member;
 
 import java.util.List;
 
 import static pickRAP.server.domain.hashtag.QHashtag.hashtag;
+import static pickRAP.server.domain.magazine.QColor.color;
 import static pickRAP.server.domain.magazine.QMagazine.magazine;
 import static pickRAP.server.domain.magazine.QMagazinePage.magazinePage;
 import static pickRAP.server.domain.member.QMember.member;
@@ -62,4 +64,12 @@ public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
                 .distinct().fetch();
     }
 
+    @Override
+    public List<Magazine> findMagazinesColorByMember(Member member) {
+        return jpaQueryFactory
+                .select(magazine)
+                .join(magazine.colors, color)
+                .where(color.member.eq(member))
+                .fetch();
+    }
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
@@ -16,11 +16,11 @@ import static pickRAP.server.domain.scrap.QScrapHashtag.scrapHashtag;
 
 @RequiredArgsConstructor
 public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
-    private final JPAQueryFactory queryFactory;
+    private final JPAQueryFactory jpaQueryFactory;
 
     @Override
     public List<Magazine> findMemberMagazines(String email) {
-        return queryFactory
+        return jpaQueryFactory
                 .selectFrom(magazine)
                 .join(magazine.member, member)
                 .where(member.email.eq(email))
@@ -30,7 +30,7 @@ public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
 
     @Override
     public List<Magazine> findMagazineByHashtag(String keyword) {
-        return queryFactory
+        return jpaQueryFactory
                 .selectFrom(magazine)
                 .join(magazine.pages, magazinePage)
                 .join(magazinePage.scrap, scrap)
@@ -52,7 +52,7 @@ public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
         builder.and(magazine.openStatus.eq(true));
         builder.and(magazine.member.email.ne(email));
 
-        return queryFactory
+        return jpaQueryFactory
                 .selectFrom(magazine)
                 .join(magazine.pages, magazinePage)
                 .join(magazinePage.scrap, scrap)

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
@@ -68,7 +68,9 @@ public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
     public List<Magazine> findMagazinesColorByMember(Member member) {
         return jpaQueryFactory
                 .select(magazine)
-                .join(magazine.colors, color)
+                .from(magazine)
+                .innerJoin(color)
+                .on(magazine.eq(color.magazine))
                 .where(color.member.eq(member))
                 .fetch();
     }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
@@ -1,5 +1,7 @@
 package pickRAP.server.repository.magazine;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import pickRAP.server.domain.category.Category;
@@ -42,4 +44,24 @@ public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
                 )
                 .distinct().fetch();
     }
+
+    @Override
+    public List<Magazine> findMagazineByHashtagAndNotWriter(List<String> keyword, String email) {
+        BooleanBuilder builder = new BooleanBuilder();
+        for(String k : keyword) {
+            builder.and(hashtag.tag.contains(k));
+        }
+        builder.and(magazine.openStatus.eq(true));
+        builder.and(magazine.member.email.ne(email));
+
+        return queryFactory
+                .selectFrom(magazine)
+                .join(magazine.pages, magazinePage)
+                .join(magazinePage.scrap, scrap)
+                .join(scrap.scrapHashtags, scrapHashtag)
+                .join(scrapHashtag.hashtag, hashtag)
+                .where(builder)
+                .distinct().fetch();
+    }
+
 }

--- a/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/magazine/MagazineRepositoryImpl.java
@@ -8,7 +8,6 @@ import pickRAP.server.domain.magazine.Magazine;
 import java.util.List;
 
 import static pickRAP.server.domain.hashtag.QHashtag.hashtag;
-import static pickRAP.server.domain.magazine.QColor.color;
 import static pickRAP.server.domain.magazine.QMagazine.magazine;
 import static pickRAP.server.domain.magazine.QMagazinePage.magazinePage;
 import static pickRAP.server.domain.member.QMember.member;
@@ -61,17 +60,6 @@ public class MagazineRepositoryImpl implements MagazineRepositoryCustom{
                 .join(scrapHashtag.hashtag, hashtag)
                 .where(builder)
                 .distinct().fetch();
-    }
-
-    @Override
-    public List<Magazine> findTop20MagazineByColor() {
-        return queryFactory
-                .select(magazine)
-                .innerJoin(magazine.colors, color)
-                .groupBy(magazine.id)
-                .orderBy(color.count().desc())
-                .limit(20)
-                .fetch();
     }
 
 }

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -275,13 +275,7 @@ public class MagazineService {
     }
 
     @Transactional
-    public List<MagazineListResponse> findMagazineByHashtag(String email, String hashtag) {
-        Member member = memberRepository.findByEmail(email).orElseThrow();
-
-        // 해시태그 tag 검색
-        // 스크랩 scrap id 검색
-        // 매거진 페이지 magazine id 검색
-        // 매거진 검색
+    public List<MagazineListResponse> findMagazineByHashtag(String hashtag) {
         List<Magazine> findMagazines = magazineRepositoryCustom.findMagazineByHashtag(hashtag);
 
         List<MagazineListResponse> collect = findMagazines.stream()

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -82,11 +82,7 @@ public class MagazineService {
         List<Magazine> findMagazines = magazineRepository.findMemberMagazines(email);
 
         List<MagazineListResponse> collect = findMagazines.stream()
-                .map(m -> MagazineListResponse.builder()
-                        .magazineId(m.getId())
-                        .coverUrl(m.getCover())
-                        .title(m.getTitle())
-                        .build())
+                .map(MagazineListResponse::new)
                 .collect(Collectors.toList());
 
         return collect;
@@ -285,11 +281,7 @@ public class MagazineService {
         List<Magazine> findMagazines = magazineRepository.findMagazineByHashtag(hashtag);
 
         List<MagazineListResponse> collect = findMagazines.stream()
-                .map(m -> MagazineListResponse.builder()
-                        .magazineId(m.getId())
-                        .coverUrl(m.getCover())
-                        .title(m.getTitle())
-                        .build())
+                .map(MagazineListResponse::new)
                 .collect(Collectors.toList());
 
         return collect;
@@ -321,11 +313,7 @@ public class MagazineService {
         }
 
         List<MagazineListResponse> collect = result.stream()
-                .map(m -> MagazineListResponse.builder()
-                        .magazineId(m.getId())
-                        .coverUrl(m.getCover())
-                        .title(m.getTitle())
-                        .build())
+                .map(MagazineListResponse::new)
                 .collect(Collectors.toList());
 
         return collect;

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -348,6 +348,7 @@ public class MagazineService {
         }
     }
 
+
     // 추천 정책 1번 : 가장 최근 제작한 3개의 매거진 해시태그 기준 추천 (40%)
     @Transactional(readOnly = true)
     public List<Magazine> getRecommendationForLatestMagazine(Member member, List<Magazine> latestCreatedMagazine){
@@ -420,7 +421,7 @@ public class MagazineService {
         List<PersonalMoodResponse> personalMoodResponses = colorRepository.getPersonalMoodAnalysisResults(member);
 
         for(PersonalMoodResponse r : personalMoodResponses) {
-            ColorType colorType = ColorType.valueOf(r.getColorStyle());
+            ColorType colorType = ColorType.from(r.getColorStyle());
             findMagazines.add(colorRepository.findMagazineByColor(colorType));
         }
 
@@ -428,7 +429,7 @@ public class MagazineService {
     }
 
     private int calculateRecommendationSize(int rate) {
-        return RECOMMENDED_TOTAL_SIZE * (int)(0.01 * rate);
+        return (int)(RECOMMENDED_TOTAL_SIZE * (0.01 * rate));
     }
 
     private List<String> getHashtagsInMagazine(List<Magazine> magazine) {

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -374,9 +374,9 @@ public class MagazineService {
 
         if(findMagazines.size() < RECOMMENDED_MAGAZINE_REMAIN_SIZE) {
             result.addAll(findMagazines);
+            result = magazineDeduplication(result);
         }
         else {
-            isFullSecond = true;
             result.addAll(findMagazines);
             result = magazineDeduplication(result);
 
@@ -433,30 +433,28 @@ public class MagazineService {
 
         // 겹치는 해시태그가 많은 순서
         for(int i = hashtags.size(); i > 0 ; i--) {
-            List<String> priorityHash = combination(hashtags, visited, 0, hashtags.size(), i);
-
-            findMagazines.addAll(
-                    magazineRepositoryCustom.findMagazineByHashtagAndNotWriter(priorityHash, email));
+            findMagazines.addAll(combination(hashtags, visited, 0, hashtags.size(), i, email));
         }
 
         return findMagazines;
     }
 
     // 조합(백트래킹) : 순서 상관없는 경우의 수
-    private List<String> combination(List<String> hashtags, boolean[] visited, int start, int n, int r) {
-        List<String> result = new ArrayList<>();
+    private List<Magazine> combination(List<String> hashtags, boolean[] visited, int start, int n, int r, String email) {
+        List<Magazine> result = new ArrayList<>();
         if(r == 0) {
+            List<String> priorityHashtags = new ArrayList<>();
             for (int i = 0; i < n; i++) {
                 if (visited[i]) {
-                    result.add(hashtags.get(i));
+                    priorityHashtags.add(hashtags.get(i));
                 }
             }
-            return result;
+            return magazineRepositoryCustom.findMagazineByHashtagAndNotWriter(priorityHashtags, email);
         }
 
         for(int i = start; i < n; i++) {
             visited[i] = true;
-            result = combination(hashtags, visited, i + 1, n, r - 1);
+            result.addAll(combination(hashtags, visited, i + 1, n, r - 1, email));
             visited[i] = false;
         }
         return result;

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import pickRAP.server.common.BaseException;
 import pickRAP.server.controller.dto.analysis.HashTagResponse;
 import pickRAP.server.controller.dto.analysis.HashtagFilterCondition;
+import pickRAP.server.controller.dto.analysis.PersonalMoodResponse;
 import pickRAP.server.controller.dto.magazine.*;
 import pickRAP.server.domain.hashtag.Hashtag;
 import pickRAP.server.domain.magazine.Color;
@@ -307,7 +308,7 @@ public class MagazineService {
             result.addAll(getRecommendationForLatestMagazine(email, latestCreatedMagazine));
             result.addAll(getRecommendationForTop3(email));
             result.addAll(getRecommendationForRespondedMagazine(email, member));
-            result.addAll(getRecommendationForPersonalMood());
+            result.addAll(getRecommendationForPersonalMood(member));
         }
 
         List<MagazineListResponse> collect = result.stream()
@@ -408,15 +409,17 @@ public class MagazineService {
     }
 
     // 추천 정책 4번 : 사용자 퍼스널 무든 분석 결과와 같은 반응을 가장 많이 받은 매거진 추천 (15%)
-    public List<Magazine> getRecommendationForPersonalMood() {
-        List<String> hashtags;
-        List<Magazine> findMagazines;
+    public List<Magazine> getRecommendationForPersonalMood(Member member) {
+        List<Magazine> findMagazines = new ArrayList<>();
 
-        // 1. 사용자의 퍼스널 무드 분석 결과 찾기
-        // 2. 그 퍼스널 무드(컬러)를 가장 많이 얻은 매거진 찾기
-        // 3. 그 매거진의 해시태그를 사용한 매거진 찾기
+        List<PersonalMoodResponse> personalMoodResponses = colorRepository.getPersonalMoodAnalysisResults(member);
 
-        return null;
+        for(PersonalMoodResponse r : personalMoodResponses) {
+            ColorType colorType = ColorType.valueOf(r.getColorStyle());
+            findMagazines.add(colorRepository.findMagazineByColor(colorType));
+        }
+
+        return findMagazines;
     }
 
     private int calculateRecommendationSize(int rate) {

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -23,6 +23,7 @@ import pickRAP.server.repository.magazine.MagazinePageRepository;
 import pickRAP.server.repository.magazine.MagazineRepository;
 import pickRAP.server.repository.magazine.MagazineRepositoryCustom;
 import pickRAP.server.repository.member.MemberRepository;
+import pickRAP.server.repository.scrap.ScrapHashtagRepository;
 import pickRAP.server.repository.scrap.ScrapRepository;
 import pickRAP.server.service.text.TextService;
 
@@ -49,6 +50,7 @@ public class MagazineService {
     private final TextService textService;
     private final ColorRepository colorRepository;
     private final HashtagRepository hashtagRepository;
+    private final ScrapHashtagRepository scrapHashtagRepository;
 
     @Transactional
     public void save(MagazineRequest request, String email) {
@@ -340,7 +342,7 @@ public class MagazineService {
         }
 
         // 1-2. 사용자의 해시태그를 바탕으로 Magazine 찾기
-        findMagazineByHashtagOrderByPriority(findMagazines, hashtags, email);
+        findMagazines = findMagazineByHashtagOrderByPriority(findMagazines, hashtags, email);
 
         if(findMagazines.size() - 1 < RECOMMENDED_MAGAZINE_FIRST_SIZE) {
             result = findMagazines;
@@ -402,7 +404,7 @@ public class MagazineService {
 
             for(MagazinePage page : m.getPages()) {
                 Scrap scrap = page.getScrap();
-                scrapHashtags.addAll(scrap.getScrapHashtags());
+                scrapHashtags.addAll(scrapHashtagRepository.findByScrapId(scrap.getId()));
             }
 
             for(ScrapHashtag scrapHashtag : scrapHashtags) {

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -306,12 +306,12 @@ public class MagazineService {
 
         // 1-1. 사용자의 최근 제작된 3개의 매거진의 해시태그 사용하기
         Member member = memberRepository.findByEmail(email).orElseThrow();
-        Optional<Magazine> latestMagazine = magazineRepository.findTop3ByMemberOrderByCreateTimeDesc(member);
+        List<Magazine> latestMagazine = magazineRepository.findTop3ByMemberOrderByCreateTimeDesc(member);
 
         List<String> hashtags = new ArrayList<>();
         List<Magazine> findMagazines = new ArrayList<>();
 
-        if (!latestMagazine.isPresent()) {
+        if (latestMagazine.size() == 0) {
             // 사용자의 매거진 제작 이력이 없다면 스크랩 해시태그 기준 추천
             List<Hashtag> findHashtags = hashtagRepository.findByMember(member);
 
@@ -336,7 +336,7 @@ public class MagazineService {
         }
         else {
             // 1-2. 사용자의 해시태그 String 리스트를 먼저 찾기
-            hashtags = getMagazineHashtags(latestMagazine.get());
+            hashtags = getMagazineHashtags(latestMagazine);
         }
 
         // 1-2. 사용자의 해시태그를 바탕으로 Magazine 찾기
@@ -394,17 +394,20 @@ public class MagazineService {
     }
 
     // 매거진의 모든 해시태그를 반환
-    private List<String> getMagazineHashtags(Magazine magazine) {
-        List<ScrapHashtag> scrapHashtags = new ArrayList<>();
+    private List<String> getMagazineHashtags(List<Magazine> magazine) {
         List<String> hashtags = new ArrayList<>();
 
-        for(MagazinePage page : magazine.getPages()) {
-            Scrap scrap = page.getScrap();
-            scrapHashtags.addAll(scrap.getScrapHashtags());
-        }
+        for(Magazine m : magazine) {
+            List<ScrapHashtag> scrapHashtags = new ArrayList<>();
 
-        for(ScrapHashtag scrapHashtag : scrapHashtags) {
-            hashtags.add(scrapHashtag.getHashtag().getTag());
+            for(MagazinePage page : m.getPages()) {
+                Scrap scrap = page.getScrap();
+                scrapHashtags.addAll(scrap.getScrapHashtags());
+            }
+
+            for(ScrapHashtag scrapHashtag : scrapHashtags) {
+                hashtags.add(scrapHashtag.getHashtag().getTag());
+            }
         }
         return hashtags;
     }

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -273,4 +273,25 @@ public class MagazineService {
             findColor.get().updateColor(colorType);
         }
     }
+
+    @Transactional
+    public List<MagazineListResponse> findMagazineByHashtag(String email, String hashtag) {
+        Member member = memberRepository.findByEmail(email).orElseThrow();
+
+        // 해시태그 tag 검색
+        // 스크랩 scrap id 검색
+        // 매거진 페이지 magazine id 검색
+        // 매거진 검색
+        List<Magazine> findMagazines = magazineRepositoryCustom.findMagazineByHashtag(hashtag);
+
+        List<MagazineListResponse> collect = findMagazines.stream()
+                .map(m -> MagazineListResponse.builder()
+                        .magazineId(m.getId())
+                        .coverUrl(m.getCover())
+                        .title(m.getTitle())
+                        .build())
+                .collect(Collectors.toList());
+
+        return collect;
+    }
 }

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -306,7 +306,7 @@ public class MagazineService {
         } else {
             result.addAll(getRecommendationForLatestMagazine(email, latestCreatedMagazine));
             result.addAll(getRecommendationForTop3(email));
-            result.addAll(getRecommendationForRespondedMagazine());
+            result.addAll(getRecommendationForRespondedMagazine(email, member));
             result.addAll(getRecommendationForPersonalMood());
         }
 
@@ -364,7 +364,7 @@ public class MagazineService {
     // 추천 정책 2번 : TOP3 해시태그 기준 추천 (30%)
     public List<Magazine> getRecommendationForTop3(String email) {
         List<String> hashtags = new ArrayList<>();
-        List<Magazine> findMagazines = new ArrayList<>();
+        List<Magazine> findMagazines;
 
         HashtagFilterCondition hashtagFilterCond = HashtagFilterCondition.builder()
                 .filter("all")
@@ -388,27 +388,35 @@ public class MagazineService {
     }
 
     // 추천 정책 3번 : 사용자가 반응한 매거진 해시태그 기준 추천 (15%)
-    public List<Magazine> getRecommendationForRespondedMagazine() {
-        List<String> hashtags = new ArrayList<>();
-        List<Magazine> findMagazines = new ArrayList<>();
+    public List<Magazine> getRecommendationForRespondedMagazine(String email, Member member) {
+        List<String> hashtags;
+        List<Magazine> findMagazines;
 
-        // 1. 사용자가 반응한 매거진 찾기
+        findMagazines = magazineRepository.findMagazinesColorByMember(member);
+        hashtags = getHashtagsInMagazine(findMagazines);
 
-        // 2. 그 매거진의 해시태그를 사용한 매거진 찾기
+        findMagazines = findMagazineByHashtagOrderByPriority(email, hashtags);
 
-        return findMagazines;
+        int recommendationSize = calculateRecommendationSize(15);
+
+        if(findMagazines.size() < recommendationSize) {
+            return findMagazines;
+        }
+        else {
+            return findMagazines.subList(0, recommendationSize);
+        }
     }
 
     // 추천 정책 4번 : 사용자 퍼스널 무든 분석 결과와 같은 반응을 가장 많이 받은 매거진 추천 (15%)
     public List<Magazine> getRecommendationForPersonalMood() {
-        List<String> hashtags = new ArrayList<>();
-        List<Magazine> findMagazines = new ArrayList<>();
+        List<String> hashtags;
+        List<Magazine> findMagazines;
 
         // 1. 사용자의 퍼스널 무드 분석 결과 찾기
         // 2. 그 퍼스널 무드(컬러)를 가장 많이 얻은 매거진 찾기
         // 3. 그 매거진의 해시태그를 사용한 매거진 찾기
 
-        return findMagazines;
+        return null;
     }
 
     private int calculateRecommendationSize(int rate) {

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -330,7 +330,7 @@ public class MagazineService {
         List<Hashtag> findHashtags = hashtagRepository.findByMember(member);
 
         if(findHashtags.isEmpty()) {
-            findMagazines = colorRepository.findTop20MagazineByColor();
+            findMagazines = colorRepository.findTop20MagazinesByColor();
         } else {
             for(Hashtag h : findHashtags) {
                 hashtags.add(h.getTag());
@@ -393,6 +393,7 @@ public class MagazineService {
         List<Magazine> findMagazines = new ArrayList<>();
 
         // 1. 사용자가 반응한 매거진 찾기
+
         // 2. 그 매거진의 해시태그를 사용한 매거진 찾기
 
         return findMagazines;

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -336,7 +336,7 @@ public class MagazineService {
     @Transactional(readOnly = true)
     public List<Magazine> getRecommendationForNoMagazine(Member member) {
         List<String> hashtags = new ArrayList<>();
-        List<Magazine> findMagazines = new ArrayList<>();
+        List<Magazine> findMagazines;
 
         List<Hashtag> findHashtags = hashtagRepository.findByMember(member);
 
@@ -405,11 +405,8 @@ public class MagazineService {
     // 추천 정책 3번 : 사용자가 반응한 매거진 해시태그 기준 추천 (15%)
     @Transactional(readOnly = true)
     public List<Magazine> getRecommendationForRespondedMagazine(Member member) {
-        List<String> hashtags;
-        List<Magazine> findMagazines;
-
-        findMagazines = magazineRepository.findMagazinesColorByMember(member);
-        hashtags = getHashtagsInMagazine(findMagazines);
+        List<Magazine> findMagazines = magazineRepository.findMagazinesColorByMember(member);
+        List<String> hashtags = getHashtagsInMagazine(findMagazines);
 
         findMagazines = findMagazineByHashtagOrderByPriority(member.getEmail(), hashtags);
 

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -309,6 +309,15 @@ public class MagazineService {
             result.addAll(getRecommendationForTop3(member));
             result.addAll(getRecommendationForRespondedMagazine(member));
             result.addAll(getRecommendationForPersonalMood(member));
+
+            DeduplicationUtils.deduplication(result, Magazine::getId);
+
+            if(result.size() < RECOMMENDED_TOTAL_SIZE) {
+                result.addAll(getRecommendationForNoMagazine(member));
+                DeduplicationUtils.deduplication(result, Magazine::getId);
+
+                result = result.subList(0, RECOMMENDED_TOTAL_SIZE);
+            }
         }
 
         List<MagazineListResponse> collect = result.stream()
@@ -413,7 +422,7 @@ public class MagazineService {
         }
     }
 
-    // 추천 정책 4번 : 사용자 퍼스널 무든 분석 결과와 같은 반응을 가장 많이 받은 매거진 추천 (15%)
+    // 추천 정책 4번 : 사용자 퍼스널 무드 분석 결과와 같은 반응을 가장 많이 받은 매거진 추천 (15%)
     @Transactional(readOnly = true)
     public List<Magazine> getRecommendationForPersonalMood(Member member) {
         List<Magazine> findMagazines = new ArrayList<>();

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -346,6 +346,7 @@ public class MagazineService {
             for(Hashtag h : findHashtags) {
                 hashtags.add(h.getTag());
             }
+            DeduplicationUtils.deduplication(hashtags);
             findMagazines = findMagazineByHashtagOrderByPriority(member.getEmail(), hashtags);
         }
 

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -330,7 +330,7 @@ public class MagazineService {
         List<Hashtag> findHashtags = hashtagRepository.findByMember(member);
 
         if(findHashtags.isEmpty()) {
-            findMagazines = magazineRepository.findTop20MagazineByColor();
+            findMagazines = colorRepository.findTop20MagazineByColor();
         } else {
             for(Hashtag h : findHashtags) {
                 hashtags.add(h.getTag());
@@ -392,6 +392,8 @@ public class MagazineService {
         List<String> hashtags = new ArrayList<>();
         List<Magazine> findMagazines = new ArrayList<>();
 
+        // 1. 사용자가 반응한 매거진 찾기
+        // 2. 그 매거진의 해시태그를 사용한 매거진 찾기
 
         return findMagazines;
     }
@@ -400,6 +402,10 @@ public class MagazineService {
     public List<Magazine> getRecommendationForPersonalMood() {
         List<String> hashtags = new ArrayList<>();
         List<Magazine> findMagazines = new ArrayList<>();
+
+        // 1. 사용자의 퍼스널 무드 분석 결과 찾기
+        // 2. 그 퍼스널 무드(컬러)를 가장 많이 얻은 매거진 찾기
+        // 3. 그 매거진의 해시태그를 사용한 매거진 찾기
 
         return findMagazines;
     }

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -317,9 +317,9 @@ public class MagazineService {
         // 최종 추천 매거진을 수집
         List<Magazine> result = new ArrayList<>();
 
-        // 1-1. +) 사용자의 최근 제작된 매거진의 해시태그 사용하기
+        // 1-1. +) 사용자의 최근 제작된 3개의 매거진의 해시태그 사용하기
         Member member = memberRepository.findByEmail(email).orElseThrow();
-        Optional<Magazine> latestMagazine = magazineRepository.findTop1ByMemberOrderByCreateTimeDesc(member);
+        Optional<Magazine> latestMagazine = magazineRepository.findTop3ByMemberOrderByCreateTimeDesc(member);
 
         List<Magazine> findMagazines = new ArrayList<>();
         if (!latestMagazine.isPresent()) {

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -330,14 +330,13 @@ public class MagazineService {
         List<Hashtag> findHashtags = hashtagRepository.findByMember(member);
 
         if(findHashtags.isEmpty()) {
-            //TODO : 스크랩 제작 이력이 없다면 가장 많은 퍼스널 무드를 받은 매거진 20개 추천
-
+            findMagazines = magazineRepository.findTop20MagazineByColor();
+        } else {
+            for(Hashtag h : findHashtags) {
+                hashtags.add(h.getTag());
+            }
+            findMagazines = findMagazineByHashtagOrderByPriority(email, hashtags);
         }
-
-        for(Hashtag h : findHashtags) {
-            hashtags.add(h.getTag());
-        }
-        findMagazines = findMagazineByHashtagOrderByPriority(email, hashtags);
 
         if(findMagazines.size() < RECOMMENDED_TOTAL_SIZE) {
             return findMagazines;

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -363,8 +363,9 @@ public class MagazineService {
         List<HashTagResponse> hashTagResponses = hashtagRepository.getHashtagAnalysisResults(hashtagFilterCond, email);
 
         hashtags = new ArrayList<>();
-        for(HashTagResponse hashtag : hashTagResponses) {
-            hashtags.add(hashtag.getTag());
+        // '기타' 태그 제외
+        for(int i = 0; i < 3; i++) {
+            hashtags.add(hashTagResponses.get(i).getTag());
         }
 
         // 2-2. 사용자의 해시태그를 바탕으로 Magazine 찾기
@@ -432,8 +433,10 @@ public class MagazineService {
 
         // 겹치는 해시태그가 많은 순서
         for(int i = hashtags.size(); i > 0 ; i--) {
-            List<String> searchHashtags = combination(hashtags, visited, 0, hashtags.size(), i);
-            findMagazines.addAll(magazineRepositoryCustom.findMagazineByHashtagAndNotWriter(searchHashtags, email));
+            List<String> priorityHash = combination(hashtags, visited, 0, hashtags.size(), i);
+
+            findMagazines.addAll(
+                    magazineRepositoryCustom.findMagazineByHashtagAndNotWriter(priorityHash, email));
         }
 
         return findMagazines;
@@ -443,20 +446,17 @@ public class MagazineService {
     private List<String> combination(List<String> hashtags, boolean[] visited, int start, int n, int r) {
         List<String> result = new ArrayList<>();
         if(r == 0) {
-            System.out.print("해시태그 종류 : ");
             for (int i = 0; i < n; i++) {
                 if (visited[i]) {
                     result.add(hashtags.get(i));
-                    System.out.print(hashtags.get(i) + ", ");
                 }
             }
-            System.out.println();
             return result;
         }
 
         for(int i = start; i < n; i++) {
             visited[i] = true;
-            combination(hashtags, visited, i + 1, n, r - 1);
+            result = combination(hashtags, visited, i + 1, n, r - 1);
             visited[i] = false;
         }
         return result;

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pickRAP.server.common.BaseException;
 import pickRAP.server.common.BaseExceptionStatus;
+import pickRAP.server.controller.dto.analysis.HashTagResponse;
+import pickRAP.server.controller.dto.analysis.HashtagFilterCondition;
 import pickRAP.server.controller.dto.magazine.*;
 import pickRAP.server.domain.magazine.Color;
 import pickRAP.server.domain.magazine.ColorType;
@@ -12,8 +14,10 @@ import pickRAP.server.domain.magazine.Magazine;
 import pickRAP.server.domain.magazine.MagazinePage;
 import pickRAP.server.domain.member.Member;
 import pickRAP.server.domain.scrap.Scrap;
+import pickRAP.server.domain.scrap.ScrapHashtag;
 import pickRAP.server.domain.scrap.ScrapType;
 import pickRAP.server.repository.color.ColorRepository;
+import pickRAP.server.repository.hashtag.HashtagRepository;
 import pickRAP.server.repository.magazine.MagazinePageRepository;
 import pickRAP.server.repository.magazine.MagazineRepository;
 import pickRAP.server.repository.magazine.MagazineRepositoryCustom;
@@ -21,9 +25,7 @@ import pickRAP.server.repository.member.MemberRepository;
 import pickRAP.server.repository.scrap.ScrapRepository;
 import pickRAP.server.service.text.TextService;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static pickRAP.server.common.BaseExceptionStatus.*;
@@ -35,6 +37,9 @@ public class MagazineService {
     final static int MAX_TEXT_LENGTH = 200;
     final static int MAX_TITLE_LENGTH = 15;
 
+    final static int RECOMMENDED_MAGAZINE_FIRST_SIZE = 8;
+    final static int RECOMMENDED_MAGAZINE_REMAIN_SIZE = 6;
+
     private final MemberRepository memberRepository;
     private final MagazineRepository magazineRepository;
     private final MagazineRepositoryCustom magazineRepositoryCustom;
@@ -42,6 +47,7 @@ public class MagazineService {
     private final ScrapRepository scrapRepository;
     private final TextService textService;
     private final ColorRepository colorRepository;
+    private final HashtagRepository hashtagRepository;
 
     @Transactional
     public void save(MagazineRequest request, String email) {
@@ -287,5 +293,133 @@ public class MagazineService {
                 .collect(Collectors.toList());
 
         return collect;
+    }
+
+    @Transactional
+    public List<MagazineListResponse> recommendedMagazineByMember(String email) {
+      /*
+      추천 로직
+      ** 피드에 보이는 위치와 순서는 랜덤
+      ** 중복 콘텐츠 우선순위 3>2>1
+
+      1. 동일한 해시태그가 사용된 매거진 (40%) - 8개
+      동일 해시태그 개수가 많은 순서대로 우선 추천
+
+      2. 사용자의 TOP3 해시태그 사용된 매거진 (30%) - 6개
+      더 많은 개수의 TOP3 해시태그를 사용한 순서대로 우선 추천
+
+      3. 사용자의 TOP3 해시태그와 연관됐지만 매거진에서는 사용되지 않은 경우 (30%) - 6개
+       */
+
+        // 기준별 콘텐츠가 비율만큼 서치되었는지 여부
+        boolean isFullFirst = false, isFullSecond = false, isFullThird = false;
+
+        // 최종 추천 매거진을 수집
+        List<Magazine> result = new ArrayList<>();
+
+        // 1-1. +) 사용자의 최근 제작된 매거진의 해시태그 사용하기
+        Member member = memberRepository.findByEmail(email).orElseThrow();
+        Optional<Magazine> latestMagazine = magazineRepository.findTop1ByMemberOrderByCreateTimeDesc(member);
+
+        List<Magazine> findMagazines = new ArrayList<>();
+        if (!latestMagazine.isPresent()) {
+            // +) 사용자의 매거진 제작 이력이 없다면 전체 매거진에서 최근 20개 랜덤 추천
+            findMagazines = magazineRepository.findTop20ByOpenStatusOrderByCreateTimeDesc(true);
+        } else {
+            // 1-2. 사용자의 해시태그 String 리스트를 먼저 찾기
+            List<String> hashtags = getMagazineHashtags(latestMagazine.get());
+
+            // 1-2. 사용자의 해시태그를 바탕으로 Magazine 찾기
+            findMagazineByHashtagOrderByPriority(findMagazines, hashtags, email);
+
+            // 검색한 매거진의 크기가 8개보다 적다면
+            if(findMagazines.size() < RECOMMENDED_MAGAZINE_FIRST_SIZE + 1) {
+                result = findMagazines;
+            } else {
+                isFullFirst = true;
+                result = findMagazines.subList(0, RECOMMENDED_MAGAZINE_FIRST_SIZE);
+            }
+
+            // 2-1. 사용자의 TOP3 해시태그 String 리스트를 먼저 찾기 - 이전에 사용한 해시태그 분석 로직 재사용
+            HashtagFilterCondition hashtagFilterCond = HashtagFilterCondition.builder()
+                    .filter("all")
+                    .build();
+
+            List<HashTagResponse> hashTagResponses = hashtagRepository.getHashtagAnalysisResults(hashtagFilterCond, email);
+
+            hashtags = new ArrayList<>();
+            for(HashTagResponse hashtag : hashTagResponses) {
+                hashtags.add(hashtag.getTag());
+            }
+
+            // 2-2. 사용자의 해시태그를 바탕으로 Magazine 찾기
+            findMagazineByHashtagOrderByPriority(findMagazines, hashtags, email);
+
+            // 검색한 매거진의 크기가 6개보다 적다면
+            if(findMagazines.size() < RECOMMENDED_MAGAZINE_REMAIN_SIZE + 1) {
+                result.addAll(findMagazines);
+            } else {
+                // 2번 기준으로 찾은 매거진 6개
+                isFullSecond = true;
+                result.addAll(findMagazines.subList(0, RECOMMENDED_MAGAZINE_REMAIN_SIZE));
+
+                // 1번 기준으로 찾은 매거진의 개수가 모자랐다면
+                if(!isFullFirst) {
+                    // 2번 기준으로 찾은 매거진으로 채우기
+                    int remainIndex = RECOMMENDED_MAGAZINE_FIRST_SIZE - result.size();
+                    for(int i = 0, j = RECOMMENDED_MAGAZINE_REMAIN_SIZE;
+                        i < remainIndex && j < findMagazines.size(); i++, j++) {
+                        result.add(findMagazines.get(j));
+                    }
+                }
+            }
+
+            // 3. 사용자의 TOP3 해시태그와 연관됐지만 매거진에서는 사용되지 않은 경우 (30%) - 6개
+
+        }
+        List<MagazineListResponse> collect = result.stream()
+                .map(m -> MagazineListResponse.builder()
+                        .magazineId(m.getId())
+                        .coverUrl(m.getCover())
+                        .title(m.getTitle())
+                        .build())
+                .collect(Collectors.toList());
+
+        return collect;
+    }
+
+    // 매거진의 모든 해시태그를 반환
+    private List<String> getMagazineHashtags(Magazine magazine) {
+        List<ScrapHashtag> scrapHashtags = new ArrayList<>();
+        List<String> hashtags = new ArrayList<>();
+
+        for(MagazinePage page : magazine.getPages()) {
+            Scrap scrap = page.getScrap();
+            scrapHashtags.addAll(scrap.getScrapHashtags());
+        }
+
+        for(ScrapHashtag scrapHashtag : scrapHashtags) {
+            hashtags.add(scrapHashtag.getHashtag().getTag());
+        }
+        return hashtags;
+    }
+
+    // List 중복 제거 (List->Set->List)
+    // 후순위로 삽입된 중복데이터가 삭제됨
+    private List<Magazine> removeMagazineDuplication(List<Magazine> magazines) {
+        return new ArrayList<Magazine>(
+                new HashSet<Magazine>(magazines));
+    }
+
+    // 해시태그로 매거진 찾기 (우선순위)
+    private List<Magazine> findMagazineByHashtagOrderByPriority(List<Magazine> findMagazines,
+                                                             List<String> hashtags, String email) {
+        // 겹치는 해시태그가 많은 순서
+        for(int i = hashtags.size()-1; i >= 0; i--) {
+            findMagazines = magazineRepositoryCustom.findMagazineByHashtagAndNotWriter(hashtags, email);
+            hashtags.remove(i);
+        }
+        // 중복 데이터 삭제
+        return removeMagazineDuplication(findMagazines);
     }
 }

--- a/src/main/java/pickRAP/server/service/magazine/MagazineService.java
+++ b/src/main/java/pickRAP/server/service/magazine/MagazineService.java
@@ -415,8 +415,10 @@ public class MagazineService {
 
         List<PersonalMoodResponse> personalMoodResponses = colorRepository.getPersonalMoodAnalysisResults(member);
 
-        for(PersonalMoodResponse r : personalMoodResponses) {
-            ColorType colorType = ColorType.from(r.getColorStyle());
+        int recommendationSize = calculateRecommendationSize(15);
+
+        for(int i = 0; i < recommendationSize && i < personalMoodResponses.size(); i++) {
+            ColorType colorType = ColorType.from(personalMoodResponses.get(i).getColorStyle());
             findMagazines.add(colorRepository.findMagazineByColor(colorType));
         }
 

--- a/src/main/java/pickRAP/server/util/deduplication/DeduplicationUtils.java
+++ b/src/main/java/pickRAP/server/util/deduplication/DeduplicationUtils.java
@@ -1,0 +1,30 @@
+package pickRAP.server.util.deduplication;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class DeduplicationUtils {
+    //Object 중복 제거
+    public static <T> List<T> deduplication(final List<T> list, Function<? super T,?> key){
+        return list.stream()
+                .filter(deduplication(key))
+                .collect(Collectors.toList());
+    }
+
+   private static <T> Predicate<T> deduplication(Function<? super T,?>key) {
+        final Set<Object> set = ConcurrentHashMap.newKeySet();
+        return predicate -> set.add(key.apply(predicate));
+    }
+
+    // String 중복 제거
+    public static List<String> deduplication(List<String> list){
+        return new ArrayList<String>(
+                new HashSet<String>(list));
+    }
+}

--- a/src/test/java/pickRAP/server/magazine/MagazineRecommServiceTest.java
+++ b/src/test/java/pickRAP/server/magazine/MagazineRecommServiceTest.java
@@ -281,23 +281,11 @@ public class MagazineRecommServiceTest {
         List<Magazine> respondedMagazineResult = magazineService.getRecommendationForRespondedMagazine(member);
         List<Magazine> personalMoodMagazineResult = magazineService.getRecommendationForPersonalMood(member);
 
-        print(latestMagazineResult);
-        print(Top3MagazineResult);
-        print(respondedMagazineResult);
-        print(personalMoodMagazineResult);
-
         //then
         assertThat(latestMagazineResult.size()).isEqualTo(8);
         assertThat(Top3MagazineResult.size()).isEqualTo(6);
         assertThat(respondedMagazineResult.size()).isEqualTo(3);
         assertThat(personalMoodMagazineResult.size()).isEqualTo(3);
 
-    }
-
-    private void print(List<Magazine> magazines) {
-        for(Magazine m : magazines) {
-            System.out.print(m.getTitle() + ", ");
-        }
-        System.out.println();
     }
 }

--- a/src/test/java/pickRAP/server/magazine/MagazineRecommServiceTest.java
+++ b/src/test/java/pickRAP/server/magazine/MagazineRecommServiceTest.java
@@ -1,0 +1,303 @@
+package pickRAP.server.magazine;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import pickRAP.server.controller.dto.auth.MemberSignUpRequest;
+import pickRAP.server.controller.dto.category.CategoryRequest;
+import pickRAP.server.controller.dto.magazine.MagazineColorRequest;
+import pickRAP.server.controller.dto.magazine.MagazineListResponse;
+import pickRAP.server.controller.dto.magazine.MagazinePageRequest;
+import pickRAP.server.controller.dto.magazine.MagazineRequest;
+import pickRAP.server.controller.dto.scrap.ScrapRequest;
+import pickRAP.server.domain.category.Category;
+import pickRAP.server.domain.magazine.Magazine;
+import pickRAP.server.domain.member.Member;
+import pickRAP.server.domain.scrap.Scrap;
+import pickRAP.server.domain.scrap.ScrapType;
+import pickRAP.server.repository.category.CategoryRepository;
+import pickRAP.server.repository.hashtag.HashtagRepository;
+import pickRAP.server.repository.magazine.MagazineRepository;
+import pickRAP.server.repository.member.MemberRepository;
+import pickRAP.server.repository.scrap.ScrapHashtagRepository;
+import pickRAP.server.repository.scrap.ScrapRepository;
+import pickRAP.server.service.auth.AuthService;
+import pickRAP.server.service.category.CategoryService;
+import pickRAP.server.service.magazine.MagazineService;
+import pickRAP.server.service.scrap.ScrapService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static pickRAP.server.magazine.RecommEnv.*;
+
+@SpringBootTest
+@Transactional
+public class MagazineRecommServiceTest {
+    @Autowired
+    ScrapRepository scrapRepository;
+
+    @Autowired
+    ScrapService scrapService;
+
+    @Autowired
+    ScrapHashtagRepository scrapHashtagRepository;
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Autowired
+    CategoryService categoryService;
+
+    @Autowired
+    MagazineRepository magazineRepository;
+
+    @Autowired
+    MagazineService magazineService;
+
+    @Autowired
+    AuthService authService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    HashtagRepository hashtagRepository;
+
+    List<Long> scrapIds = new ArrayList<>();
+
+    private MemberSignUpRequest memberSignUpRequest(String email, String password, String name) {
+        return MemberSignUpRequest.builder()
+                .email(email)
+                .password(password)
+                .name(name)
+                .build();
+    }
+
+    private CategoryRequest categoryRequest(String name) {
+        return CategoryRequest.builder()
+                .name(name)
+                .build();
+    }
+
+    private ScrapRequest scrapRequest(Long categoryId, List<String> hashtags) {
+        return ScrapRequest.builder()
+                .title("제목")
+                .content("내용")
+                .memo("메모")
+                .scrapType("text")
+                .hashtags(hashtags)
+                .categoryId(categoryId)
+                .build();
+    }
+
+    private Long saveCover(Member member, Category category, String title) {
+        Scrap cover = Scrap.builder()
+                .title(title)
+                .memo("커버 메모")
+                .fileUrl("커버 URL")
+                .scrapType(ScrapType.IMAGE)
+                .build();
+        cover.setMember(member);
+        cover.setCategory(category);
+
+        return scrapRepository.save(cover).getId();
+    }
+
+    private List<MagazinePageRequest> magazinePageRequests() {
+        List<MagazinePageRequest> list = new ArrayList<>();
+        for(int i = 0; i < scrapIds.size(); i++) {
+            list.add(
+                    MagazinePageRequest.builder()
+                            .scrapId(scrapIds.get(i))
+                            .text("매거진 텍스트")
+                            .build()
+            );
+        }
+        return list;
+    }
+
+    private MagazineRequest magazineRequest(String title, Long coverScrapId, List<MagazinePageRequest> pageList) {
+        return MagazineRequest.builder()
+                .title(title)
+                .openStatus(true)
+                .coverScrapId(coverScrapId)
+                .pageList(pageList)
+                .build();
+    }
+
+    private MagazineColorRequest magazineColorRequest(String colorType) {
+        MagazineColorRequest r = new MagazineColorRequest();
+        r.setColorType(colorType);
+        return r;
+    }
+
+    void categorySetting() {
+        int index = 0;
+        while(index < 4) { categoryService.save(categoryRequest(String.valueOf(index++)), Mem1EMAIL); }
+        categoryService.save(categoryRequest(String.valueOf(index++)), Mem2EMAIL);
+        for(int i = index; i < 31; i++) { categoryService.save(categoryRequest(String.valueOf(i)), Mem4EMAIL); }
+    }
+
+    void MagazineSetting(String email, String categoryName, List<String> hashtags) {
+        Member member = memberRepository.findByEmail(email).get();
+        Category category = categoryRepository.findMemberCategory(categoryName, member.getEmail()).get();
+        scrapIds = new ArrayList<>();
+
+        // 스크랩 생성
+        scrapService.save(scrapRequest(category.getId(), hashtags), null, member.getEmail());
+
+        if(email.equals(Mem2EMAIL)) { return; }
+
+        Long coverId = saveCover(member, category, "매거진 커버");
+
+        List<Scrap> scrapList = scrapRepository.findByCategoryId(category.getId());
+        for(Scrap s : scrapList) { scrapIds.add(s.getId()); }
+
+        // 매거진 생성
+        List<MagazinePageRequest> magazinePageRequest = magazinePageRequests();
+        MagazineRequest magazineRequest = magazineRequest(hashtags.get(0), coverId, magazinePageRequest);
+
+        magazineService.save(magazineRequest, member.getEmail());
+    }
+
+    void PersonalMoodSetting(String email, String hashtag, String colorType) {
+        Long magazineId = magazineService.findMagazineByHashtag(hashtag).get(0).getMagazineId();
+        magazineService.addMagazineColor(email, magazineId, magazineColorRequest(colorType));
+    }
+
+    @BeforeEach
+    void setup() {
+        List<MemberSignUpRequest> memberSignUpRequestList = new ArrayList<>();
+        memberSignUpRequestList.add(memberSignUpRequest(Mem1EMAIL, PASSWORD, "유정민"));
+        memberSignUpRequestList.add(memberSignUpRequest(Mem2EMAIL, PASSWORD, "윤태민"));
+        memberSignUpRequestList.add(memberSignUpRequest(Mem3EMAIL, PASSWORD, "문민혁"));
+        memberSignUpRequestList.add(memberSignUpRequest(Mem4EMAIL, PASSWORD, "대량주"));
+        memberSignUpRequestList.add(memberSignUpRequest(Mem5EMAIL, PASSWORD, "퍼스널"));
+
+        for(MemberSignUpRequest m : memberSignUpRequestList) {
+            authService.signUp(m);
+        }
+
+        categorySetting();
+
+        int index = 0;
+        // 기준이 되는 멤버 (TOP3: 백엔드, IT, 구름)
+        MagazineSetting(Mem1EMAIL, String.valueOf(index), Arrays.asList("백엔드", "IT", "구름"));
+        MagazineSetting(Mem1EMAIL, String.valueOf(index), Arrays.asList("백엔드", "IT", "구름"));
+        MagazineSetting(Mem1EMAIL, String.valueOf(index++), Arrays.asList("백엔드", "IT", "구름"));
+        MagazineSetting(Mem1EMAIL, String.valueOf(index++), Arrays.asList("공스타"));
+        MagazineSetting(Mem1EMAIL, String.valueOf(index++), Arrays.asList("셀카"));
+        MagazineSetting(Mem1EMAIL, String.valueOf(index++), Arrays.asList("피크랩"));
+
+        // 스크랩만 있는 멤버
+        MagazineSetting(Mem2EMAIL, String.valueOf(index++), Arrays.asList("민머리", "대머리", "탈모"));
+
+        // 매거진 대량 생산 멤버
+        // 추천 정책 0번-(1) : 스크랩 해시태그
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("민머리"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("탈모"));
+
+        // 추천 정책 0번-(2) : 가장 많은 퍼스널 무드
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("퍼스널"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("무드"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("컬러"));
+
+        // 추천 정책 1번 : 최근 매거진 3개
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("공스타"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("공스타"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("공스타"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("셀카"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("셀카"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("셀카"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("피크랩"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("피크랩"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("피크랩"));
+
+        // 추천 정책 2번 : TOP3
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("IT"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("IT"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("IT"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("IT"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("IT", "백엔드"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("IT", "백엔드"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("IT", "백엔드"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("IT", "백엔드", "구름"));
+
+        // 옵션 : 무관한 매거진
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("무관"));
+
+        // 추천 정책 3번 : 사용자가 반응한 매거진
+        PersonalMoodSetting(Mem1EMAIL, "탈모", "맑은 민트");
+        PersonalMoodSetting(Mem1EMAIL, "민머리", "맑은 민트");
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("프론트엔드", "탈모"));
+        MagazineSetting(Mem4EMAIL, String.valueOf(index++), Arrays.asList("개발자", "민머리"));
+
+        // 추천 정책 4번 : 사용자의 퍼스널 무드 분석 결과 -> 같은 반응 매거진
+        PersonalMoodSetting(Mem5EMAIL, "탈모", "화려한 레드");
+        PersonalMoodSetting(Mem5EMAIL, "퍼스널", "화려한 레드");
+        PersonalMoodSetting(Mem5EMAIL, "무드", "시원한 블루");
+        PersonalMoodSetting(Mem5EMAIL, "컬러", "포근한 오렌지");
+
+        PersonalMoodSetting(Mem5EMAIL, "공스타", "포근한 오렌지");
+        PersonalMoodSetting(Mem5EMAIL, "셀카", "화려한 레드");
+        PersonalMoodSetting(Mem5EMAIL, "피크랩", "시원한 블루");
+    }
+
+    @Test
+    @DisplayName("매거진 추천 - 통합")
+    void recommendationMagazineTest() {
+        // given
+
+        // when
+        List<MagazineListResponse> standardMemberResult = magazineService.recommendedMagazineByMember(Mem1EMAIL);
+        List<MagazineListResponse> noMagazineMemberResult = magazineService.recommendedMagazineByMember(Mem2EMAIL);
+        List<MagazineListResponse> noScrapMemberResult = magazineService.recommendedMagazineByMember(Mem3EMAIL);
+
+        // then
+        assertThat(standardMemberResult.size()).isEqualTo(20);
+
+        assertThat(noMagazineMemberResult.size()).isEqualTo(4);
+
+        assertThat(noScrapMemberResult.size()).isEqualTo(8);
+        assertThat(noScrapMemberResult.get(0).getTitle()).isEqualTo("탈모");
+    }
+
+    @Test
+    @DisplayName("매거진 추천 - 단위")
+    void recommendationUnitMagazineTest() {
+        // given
+        Member member = memberRepository.findByEmail(Mem1EMAIL).orElseThrow();
+        List<Magazine> latestCreatedMagazine = magazineRepository.findTop3ByMemberOrderByCreateTimeDesc(member);
+
+        // when
+        List<Magazine> latestMagazineResult = magazineService.getRecommendationForLatestMagazine(member, latestCreatedMagazine);
+        List<Magazine> Top3MagazineResult = magazineService.getRecommendationForTop3(member);
+        List<Magazine> respondedMagazineResult = magazineService.getRecommendationForRespondedMagazine(member);
+        List<Magazine> personalMoodMagazineResult = magazineService.getRecommendationForPersonalMood(member);
+
+        print(latestMagazineResult);
+        print(Top3MagazineResult);
+        print(respondedMagazineResult);
+        print(personalMoodMagazineResult);
+
+        //then
+        assertThat(latestMagazineResult.size()).isEqualTo(8);
+        assertThat(Top3MagazineResult.size()).isEqualTo(6);
+        assertThat(respondedMagazineResult.size()).isEqualTo(3);
+        assertThat(personalMoodMagazineResult.size()).isEqualTo(3);
+
+    }
+
+    private void print(List<Magazine> magazines) {
+        for(Magazine m : magazines) {
+            System.out.print(m.getTitle() + ", ");
+        }
+        System.out.println();
+    }
+}

--- a/src/test/java/pickRAP/server/magazine/MagazineServiceTest.java
+++ b/src/test/java/pickRAP/server/magazine/MagazineServiceTest.java
@@ -369,15 +369,7 @@ public class MagazineServiceTest {
         List<MagazineListResponse> response = magazineService.recommendedMagazineByMember("member1@test.com");
 
         // then
-        //assertThat(response.size()).isEqualTo(5);
-
-        for(MagazineListResponse r : response) {
-            System.out.println(r.getTitle());
-        }
-//        assertThat(response.get(0).getTitle()).isEqualTo("3개 매거진");
-//        assertThat(response.get(1).getTitle()).isEqualTo("2개 매거진");
-//        assertThat(response.get(2).getTitle()).isEqualTo("3개 매거진");
-//        assertThat(response.get(3).getTitle()).isEqualTo("1개 매거진");
+        assertThat(response.size()).isEqualTo(3);
     }
 
     @Test

--- a/src/test/java/pickRAP/server/magazine/MagazineServiceTest.java
+++ b/src/test/java/pickRAP/server/magazine/MagazineServiceTest.java
@@ -243,14 +243,26 @@ public class MagazineServiceTest {
     @DisplayName("매거진 검색")
     void searchMagazineTest() {
         // given
-        String keyword = "완전";
+        Member member = memberRepository.findByEmail(EMAIL_OK).get();
+        Category category = categoryRepository.findMemberCategory("여행", member.getEmail()).get();
+        List<Scrap> scrapList = scrapRepository.findByCategoryId(category.getId());
+
+        for(Scrap s : scrapList) {
+            scrapIds.add(s.getId());
+        }
+        List<MagazinePageRequest> magazinePageRequest = magazinePageRequests();
+        MagazineRequest magazineRequest = magazineRequest("매거진 제목", true, coverIds.get(0), magazinePageRequest);
+
+        magazineService.save(magazineRequest, member.getEmail());
+
+        String keyword = "대한";
 
         // when
         List<MagazineListResponse> searchMagazines = magazineService.findMagazineByHashtag(keyword);
 
         // then
         assertThat(searchMagazines.size()).isEqualTo(1);
-        assertThat(searchMagazines.get(0).getTitle()).isEqualTo("무관 매거진");
+        assertThat(searchMagazines.get(0).getTitle()).isEqualTo("매거진 제목");
     }
 
     @Test

--- a/src/test/java/pickRAP/server/magazine/MagazineServiceTest.java
+++ b/src/test/java/pickRAP/server/magazine/MagazineServiceTest.java
@@ -212,7 +212,7 @@ public class MagazineServiceTest {
 
         // 2: 매거진 대량 양산용 멤버
         member = memberRepository.findByEmail("member2@test.com").get();
-        // 2-1) TOP3 설정
+        // 2-1) 3개 일치
         Category category1 = categoryRepository.findMemberCategory("top3", member.getEmail()).get();
 
         scrapService.save(scrapRequest(category1.getId(), "IT", "개발", "백엔드"), null, member.getEmail());
@@ -229,7 +229,7 @@ public class MagazineServiceTest {
 
         magazineService.save(magazineRequest, member.getEmail());
 
-        // 2-2) 최근 매거진 해시태그
+        // 2-2) 1개 일치
         Category category2 = categoryRepository.findMemberCategory("latest", member.getEmail()).get();
 
         scrapService.save(scrapRequest(category2.getId(), "맛집", "무관한", "해시태그"), null, member.getEmail());
@@ -244,7 +244,7 @@ public class MagazineServiceTest {
 
         magazineService.save(magazineRequest, member.getEmail());
 
-        // 2-2) 최근 매거진 해시태그 (우선순위 더 높음)
+        // 2-2) 2개 일치
         scrapService.save(scrapRequest(category2.getId(), "맛집", "IT", "해시태그"), null, member.getEmail());
         coverId = saveCover(member, category2, "2개 매거진");
 
@@ -366,10 +366,24 @@ public class MagazineServiceTest {
         // given
 
         // when
-        List<MagazineListResponse> response = magazineService.recommendedMagazineByMember("member1@test.com");
+        List<MagazineListResponse> recommendedMagazines = magazineService.recommendedMagazineByMember("member1@test.com");
 
         // then
-        assertThat(response.size()).isEqualTo(3);
+        assertThat(recommendedMagazines.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("매거진 검색")
+    void searchMagazineTest() {
+        // given
+        String keyword = "완전";
+
+        // when
+        List<MagazineListResponse> searchMagazines = magazineService.findMagazineByHashtag(keyword);
+
+        // then
+        assertThat(searchMagazines.size()).isEqualTo(1);
+        assertThat(searchMagazines.get(0).getTitle()).isEqualTo("무관 매거진");
     }
 
     @Test

--- a/src/test/java/pickRAP/server/magazine/RecommEnv.java
+++ b/src/test/java/pickRAP/server/magazine/RecommEnv.java
@@ -1,0 +1,12 @@
+package pickRAP.server.magazine;
+
+public class RecommEnv {
+    public static final String Mem1EMAIL = "recommedation1@test.com";
+    public static final String Mem2EMAIL = "recommedation2@test.com";
+    public static final String Mem3EMAIL = "recommedation3@test.com";
+    public static final String Mem4EMAIL = "recommedation4@test.com";
+    public static final String Mem5EMAIL = "recommedation5@test.com";
+
+    public static final String PASSWORD = "test1234!";
+
+}


### PR DESCRIPTION
## 📮 관련 이슈
- Resolved: #150 

## ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->
- 매거진 추천 API 구현
  - 매거진 추천 테스트 코드
- 매거진 검색 API 구현
  - 매거진 검색 테스트 코드
- 매거진 추천 코드 리팩토링

## 🌱 PR 포인트
- 매거진 검색
  - 매거진 내 스크랩 해시태그 기반으로 검색 기능 구현 했습니다.
- 매거진 추천
  - 매거진 추천 정책 변경에 따라 기존 코드 리팩토링하며 로직 변경했습니다.
  - 추천 정책별로 메소드화하여 코드 가독성을 높이고자 했는데 코드 리뷰할 때 참고 부탁드립니다!
  - 각 메소드마다 정책에 대한 주석을 붙여 놓았습니다.
  - 테스트코드를 위해서느 메소드마다 `@Transactional`을 달아놓았는데 다른 아이디어도 마구마구 던져주세요!

- 매거진 추천 정책 0번(100%) : 매거진 제작 이력이 없는 사용자에게 추천
  - 스크랩 제작 경험이 있는 사용자 : 스크랩 해시태그 기반으로 매거진 추천
  - 스크랩 제작 경험이 없는 사용자 : 가장 많은 수의 퍼스널 무드를 받은 매거진 20개 추천 
- 매거진 추천 정책 1번(40%) : 가장 최근 제작한 3개의 매거진 해시태그 기준으로 추천
  - `findMagazineByHashtagOrderByPriority` : 조합 알고리즘을 활용하여 가장 많은 수의 해시태그가 적용된 매거진을 우선 추천
- 매거진 추천 정책 2번(30%) : 사용자 TOP3 해시태그 기반 추천 
  - `calculateRecommendationSize` : 비율별 계산 (확장성 고려하여 전체 개수 전역 변수화)
- 매거진 추천 정책 3번(15%) : 사용자가 반응했던 매거진의 해시태그 기반 추천
- 매거진 추천 정책 4번(15%) : 사용자의 퍼스널 무드 기반
  - `findMagazineByColor` : 해당 color를 가장 많이 받은 매거진 순서대로 쿼리

- 중복 데이터 처리를 위해 util > deduplication > DeduplicationUtils 추가
  - Object 중복 제거(List, key)
  - String 중복 제거 
- 추후 예외 사항 처리 필요 (고민사항 참고)
 
## 💡 고민사항
- 매거진 순서가 항상 일정하게 유지될 것 같은데 이를 매번 랜덤하게 어떻게 제공하는 것이 좋을까요?
- 매거진 추천 정책마다 고정 비율이 존재하는데, 고정 비율만큼의 개수보다 더 적게 매거진이 추천되는 경우는 어떻게 처리하면 좋을까요?
  - e.g. 특이한 해시태그로 인해 추천되는 매거진이 없는 경우 무엇으로 채우면 좋을지
- 매거진 추천 test는 최소 20개의 매거진이 추천되어야 하기 때문에 다량의 테스트 데이터를 save 해야 합니다! 그래서 코드가 상당히 길어지고, 테스트 시간이 지연되는데 이를 어떻게 해결할 수 있을지.. 😢


## 📸 스크린샷
|스크린샷|
|:--:|
|<img width="827" alt="image" src="https://user-images.githubusercontent.com/78305431/221762346-43028545-ea00-4fd5-9918-1ab9a9b0aeb9.png">|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
