### PR TITLE
🚑Hotfix : S3 Bean 주입 순서 설정

### DIFF
--- a/src/main/java/pickRAP/server/config/s3/S3Config.java
+++ b/src/main/java/pickRAP/server/config/s3/S3Config.java
@@ -6,8 +6,10 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 
 @Configuration
+@Component("s3Config")
 public class S3Config {
 
     private static String accessKey;

--- a/src/main/java/pickRAP/server/util/s3/S3Util.java
+++ b/src/main/java/pickRAP/server/util/s3/S3Util.java
@@ -26,7 +26,7 @@ public class S3Util {
 
     private static String bucket;
 
-    @Value("${cloud.aws.credentials.access-key}")
+    @Value("${cloud.aws.s3.bucket}")
     public void setBucket(String bucket) {
         this.bucket = bucket;
     }

--- a/src/main/java/pickRAP/server/util/s3/S3Util.java
+++ b/src/main/java/pickRAP/server/util/s3/S3Util.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.model.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import pickRAP.server.common.BaseException;
@@ -18,16 +19,17 @@ import static pickRAP.server.config.s3.S3Config.amazonS3Client;
 
 @Component
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@DependsOn("s3Config")
 public class S3Util {
+
+    private static final AmazonS3Client amazonS3Client = amazonS3Client();
 
     private static String bucket;
 
-    @Value("${cloud.aws.s3.bucket}")
-    public void setBucket(String buc) {
-        bucket = buc;
+    @Value("${cloud.aws.credentials.access-key}")
+    public void setBucket(String bucket) {
+        this.bucket = bucket;
     }
-
-    private static final AmazonS3Client amazonS3Client = amazonS3Client();
 
     //단일 파일 올리기 (s3 파일 이름 반환)
     public static String uploadFile(MultipartFile multipartFile, String dir, String scrapType) {


### PR DESCRIPTION
## 📮 관련 이슈
- Resolved: #168 

## ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->
S3Config : `@Component("s3Config")`
순서 설정을 위한 이름 붙이기

S3Util : `@DependsOn("s3Config")`
S3Util bean 주입 이전에 s3Config부터 bean 주입하기

## 🌱 PR 포인트
- 로컬에서 순서를 반대로 설정해보니 서버와 같은 오류가 발생함. 
