### PR TITLE
프로필 설정 API 개발

### DIFF
--- a/src/main/java/pickRAP/server/common/BaseExceptionStatus.java
+++ b/src/main/java/pickRAP/server/common/BaseExceptionStatus.java
@@ -19,7 +19,9 @@ public enum BaseExceptionStatus {
     EXPIRED_REFRESH(HttpStatus.UNAUTHORIZED, 2007, "재발급 실패"),
 
     // 회원
-
+    INTRODUCTION_LONG(HttpStatus.BAD_REQUEST, 3001, "소개글이 25자를 초과했습니다"),
+    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, 3002, "이미 존재하는 닉네임입니다"),
+    EXCEED_HASHTAG(HttpStatus.BAD_REQUEST, 3003, "해시태그는 4개까지 선택 가능합니다"),
 
     // 스크랩
     NOT_SUPPORT_FILE(HttpStatus.BAD_REQUEST, 4001, "지원하지 않는 파일 형식입니다"),

--- a/src/main/java/pickRAP/server/common/BooleanToYNConverter.java
+++ b/src/main/java/pickRAP/server/common/BooleanToYNConverter.java
@@ -1,0 +1,18 @@
+package pickRAP.server.common;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class BooleanToYNConverter implements AttributeConverter<Boolean, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Boolean attribute) {
+        return (attribute != null && attribute) ? "Y" : "N";
+    }
+
+    @Override
+    public Boolean convertToEntityAttribute(String dbData) {
+        return dbData.equals("Y");
+    }
+}

--- a/src/main/java/pickRAP/server/controller/HashtagController.java
+++ b/src/main/java/pickRAP/server/controller/HashtagController.java
@@ -1,0 +1,39 @@
+package pickRAP.server.controller;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pickRAP.server.common.BaseResponse;
+import pickRAP.server.controller.dto.Hashtag.HashtagPageResponse;
+import pickRAP.server.service.auth.AuthService;
+import pickRAP.server.service.hashtag.HashtagService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/hashtag")
+public class HashtagController {
+
+    private final AuthService authService;
+
+    private final HashtagService hashtagService;
+
+    @GetMapping
+    @ApiOperation(value = "프로필 설정을 위한 해시태그 가져오기", notes = "페이징, 중복X<br>" +
+            "초기 요청 : https://api.pickrap.com/hashtag?page=<br>" +
+            "이후 요청 : https://api.pickrap.com/hashtag?page=next_hashtag_id<br>" +
+            "next_hashtag_id : 이전 응답에 포함, null 값이면 이후 페이지 없음")
+    @ApiResponse(responseCode = "500", description = "서버 예외")
+    public ResponseEntity<BaseResponse<HashtagPageResponse>> getSliceHashtag(@PageableDefault(size = 20) Pageable pageable) {
+        String email = authService.getUserEmail();
+
+        HashtagPageResponse hashtagPageResponse = hashtagService.getSliceHashtagPageResponse(email, pageable);
+
+        return ResponseEntity.ok(new BaseResponse(hashtagPageResponse));
+    }
+}

--- a/src/main/java/pickRAP/server/controller/ProfileController.java
+++ b/src/main/java/pickRAP/server/controller/ProfileController.java
@@ -13,42 +13,35 @@ import pickRAP.server.controller.dto.profile.ProfileResponse;
 import pickRAP.server.service.auth.AuthService;
 import pickRAP.server.service.profile.ProfileService;
 
-import java.io.IOException;
-
 import static pickRAP.server.common.BaseExceptionStatus.SUCCESS;
-import static pickRAP.server.util.s3.S3Util.uploadFile;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("profile")
 public class ProfileController {
 
     private final ProfileService profileService;
     private final AuthService authService;
 
-    @GetMapping("/profile")
+    @GetMapping
     @ApiOperation(value = "프로필 정보 가져오기", notes = "유저 프로필 정보 가져오기")
-    @ApiResponses({
-            @ApiResponse(responseCode = "500", description = "서버 예외")
-    })
-    public ResponseEntity<BaseResponse> getProfile() {
+    @ApiResponse(responseCode = "500", description = "서버 예외")
+    public ResponseEntity<BaseResponse<ProfileResponse>> getProfile() {
         ProfileResponse response = profileService.getProfile(authService.getUserEmail());
+
         return ResponseEntity.ok(new BaseResponse(response));
     }
 
-    @PostMapping("/profile")
-    @ApiOperation(value = "프로필 설정", notes = "유저 프로필 이름, 사진, 소개글, 키워드를 설정")
+    @PutMapping
+    @ApiOperation(value = "프로필 설정", notes = "유저 프로필 이름, 사진, 소개글, 해시태그 설정")
     @ApiResponses({
+            @ApiResponse(responseCode = "400", description = "2006 - 필수값 미입력(닉네임, 소개글)<br>" +
+                    "3001 - 소개글 길이 초과<br>3002 - 닉네임 중복<br>3003 - 해시태그 4개 초과"),
             @ApiResponse(responseCode = "500", description = "서버 예외")
     })
-    public ResponseEntity<BaseResponse> updateProfile(@RequestPart("profile-request") ProfileRequest request,
-                                                      @RequestPart("file") MultipartFile multipartFile
-                                                     ) throws IOException {
-        String profileImageUrl = "";
-        if(!multipartFile.isEmpty()) {
-            profileImageUrl = uploadFile(multipartFile, "content", "image");
-        }
-
-        profileService.updateProfile(authService.getUserEmail(), request, profileImageUrl);
+    public ResponseEntity<BaseResponse> updateProfile(@RequestPart("profile_request") ProfileRequest profileRequest,
+                                                      @RequestPart("file") MultipartFile multipartFile) {
+        profileService.updateProfile(authService.getUserEmail(), profileRequest, multipartFile);
 
         return ResponseEntity.ok(new BaseResponse(SUCCESS));
     }

--- a/src/main/java/pickRAP/server/controller/dto/Hashtag/HashtagPageResponse.java
+++ b/src/main/java/pickRAP/server/controller/dto/Hashtag/HashtagPageResponse.java
@@ -1,0 +1,23 @@
+package pickRAP.server.controller.dto.Hashtag;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class HashtagPageResponse {
+
+    @JsonProperty("next_hashtag_id")
+    Long nextHashtagId;
+
+    @JsonProperty("hashtag_responses")
+    List<HashtagResponse> hashtagResponses;
+
+    @Builder
+    public HashtagPageResponse(Long nextHashtagId, List<HashtagResponse> hashtagResponses) {
+        this.nextHashtagId = nextHashtagId;
+        this.hashtagResponses = hashtagResponses;
+    }
+}

--- a/src/main/java/pickRAP/server/controller/dto/Hashtag/HashtagResponse.java
+++ b/src/main/java/pickRAP/server/controller/dto/Hashtag/HashtagResponse.java
@@ -1,0 +1,20 @@
+package pickRAP.server.controller.dto.Hashtag;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class HashtagResponse {
+
+    String tag;
+
+    boolean use;
+
+    @Builder
+    @QueryProjection
+    public HashtagResponse(String tag, boolean use) {
+        this.tag = tag;
+        this.use = use;
+    }
+}

--- a/src/main/java/pickRAP/server/controller/dto/profile/ProfileRequest.java
+++ b/src/main/java/pickRAP/server/controller/dto/profile/ProfileRequest.java
@@ -1,10 +1,21 @@
 package pickRAP.server.controller.dto.profile;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ProfileRequest {
-    String name;
+
+    String nickname;
+
     String introduction;
-    String[] keywords;
+
+    List<String> hashtags;
 }

--- a/src/main/java/pickRAP/server/controller/dto/profile/ProfileResponse.java
+++ b/src/main/java/pickRAP/server/controller/dto/profile/ProfileResponse.java
@@ -1,13 +1,24 @@
 package pickRAP.server.controller.dto.profile;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import pickRAP.server.controller.dto.Hashtag.HashtagResponse;
+
+import java.util.List;
 
 @Data
+@Builder
 @AllArgsConstructor
 public class ProfileResponse {
-    String name;
+
+    String nickname;
+
     String introduction;
+
+    @JsonProperty("profile_image_url")
     String profileImageUrl;
-    String[] keywords;
+
+    List<HashtagResponse> hashtags;
 }

--- a/src/main/java/pickRAP/server/domain/hashtag/Hashtag.java
+++ b/src/main/java/pickRAP/server/domain/hashtag/Hashtag.java
@@ -27,12 +27,12 @@ public class Hashtag extends BaseEntity {
     private Member member;
 
     @Convert(converter = BooleanToYNConverter.class)
-    private boolean profile;
+    private boolean usedInProfile;
 
     @Builder
     public Hashtag(String tag, Member member) {
         this.tag = tag;
-        this.profile = false;
+        this.usedInProfile = false;
         setMember(member);
     }
 
@@ -41,7 +41,7 @@ public class Hashtag extends BaseEntity {
         member.getHashtags().add(this);
     }
 
-    public void updateProfile(boolean profile) {
-        this.profile = profile;
+    public void updateProfile(boolean usedInProfile) {
+        this.usedInProfile = usedInProfile;
     }
 }

--- a/src/main/java/pickRAP/server/domain/hashtag/Hashtag.java
+++ b/src/main/java/pickRAP/server/domain/hashtag/Hashtag.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import pickRAP.server.common.BaseEntity;
+import pickRAP.server.common.BooleanToYNConverter;
 import pickRAP.server.domain.member.Member;
 
 import javax.persistence.*;
@@ -25,9 +26,13 @@ public class Hashtag extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Convert(converter = BooleanToYNConverter.class)
+    private boolean profile;
+
     @Builder
     public Hashtag(String tag, Member member) {
         this.tag = tag;
+        this.profile = false;
         setMember(member);
     }
 
@@ -36,5 +41,7 @@ public class Hashtag extends BaseEntity {
         member.getHashtags().add(this);
     }
 
-
+    public void updateProfile(boolean profile) {
+        this.profile = profile;
+    }
 }

--- a/src/main/java/pickRAP/server/domain/member/Member.java
+++ b/src/main/java/pickRAP/server/domain/member/Member.java
@@ -11,10 +11,14 @@ import pickRAP.server.domain.magazine.Color;
 import pickRAP.server.domain.magazine.Magazine;
 import pickRAP.server.domain.scrap.Scrap;
 import pickRAP.server.domain.text.Text;
+import pickRAP.server.service.auth.DefaultProfileEnv;
 
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+
+import static pickRAP.server.domain.member.Authority.ROLE_USER;
+import static pickRAP.server.service.auth.DefaultProfileEnv.*;
 
 @Entity
 @Getter
@@ -36,7 +40,7 @@ public class Member extends BaseEntity {
 
     private String introduction;
 
-    private String keyword;
+    private String nickname;
 
     @Enumerated(EnumType.STRING)
     private Authority authority;
@@ -63,27 +67,20 @@ public class Member extends BaseEntity {
     private List<Color> colors = new ArrayList<>();
 
     @Builder
-    public Member(String email, SocialType socialType, String password, String name, String profileImageUrl) {
+    public Member(String email, SocialType socialType, String password, String name) {
         this.email = email;
         this.password = password;
         this.name = name;
-        this.profileImageUrl = profileImageUrl;
-        this.authority = Authority.ROLE_USER;
+        this.profileImageUrl = DEFAULT_IMAGE_URL;
+        this.introduction = DEFAULT_INTRODUCTION;
+        this.nickname = DEFAULT_NICKNAME;
+        this.authority = ROLE_USER;
         this.socialType = socialType;
     }
 
-    public void updateProfile(String name, String introduction, String profileImageUrl, String keyword) {
-        if(name != null) {
-            this.name = name;
-        }
-        if(introduction != null) {
-            this.introduction = introduction;
-        }
-        if(!profileImageUrl.equals("")) {
-            this.profileImageUrl = profileImageUrl;
-        }
-        if(keyword != null) {
-            this.keyword = keyword;
-        }
+    public void updateProfile(String nickname, String introduction, String profileImageUrl) {
+        this.nickname = nickname;
+        this.introduction = introduction;
+        this.profileImageUrl = profileImageUrl;
     }
 }

--- a/src/main/java/pickRAP/server/repository/hashtag/HashtagRepository.java
+++ b/src/main/java/pickRAP/server/repository/hashtag/HashtagRepository.java
@@ -12,11 +12,11 @@ public interface HashtagRepository extends JpaRepository<Hashtag, Long>, Hashtag
 
     List<Hashtag> findByMember(Member member);
 
-    @Query("select DISTINCT h.tag from Hashtag h where h.member = :member and h.profile = :profile order by h.tag")
-    List<String> findTagDistinct(@Param("member") Member member, @Param("profile") boolean profile);
+    @Query("select DISTINCT h.tag from Hashtag h where h.member = :member and h.usedInProfile = :usedInProfile order by h.tag")
+    List<String> findTagDistinct(@Param("member") Member member, @Param("usedInProfile") boolean usedInProfile);
 
-    @Query("select h from Hashtag h where h.member = :member and h.profile = true")
-    List<Hashtag> findHashtagUseProfile(@Param("member") Member member);
+    @Query("select h from Hashtag h where h.member = :member and h.usedInProfile = true")
+    List<Hashtag> findHashtagUsedInProfile(@Param("member") Member member);
 
     List<Hashtag> findByMemberAndTag(Member member, String tag);
 

--- a/src/main/java/pickRAP/server/repository/hashtag/HashtagRepository.java
+++ b/src/main/java/pickRAP/server/repository/hashtag/HashtagRepository.java
@@ -7,12 +7,17 @@ import pickRAP.server.domain.hashtag.Hashtag;
 import pickRAP.server.domain.member.Member;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface HashtagRepository extends JpaRepository<Hashtag, Long>, HashtagRepositoryCustom {
 
-    @Query("select h from Hashtag h where h.tag = :tag and h.member = :member")
-    Optional<Hashtag> findMemberHashtag(@Param("tag") String tag, @Param("member")Member member);
-
     List<Hashtag> findByMember(Member member);
+
+    @Query("select DISTINCT h.tag from Hashtag h where h.member = :member and h.profile = :profile order by h.tag")
+    List<String> findTagDistinct(@Param("member") Member member, @Param("profile") boolean profile);
+
+    @Query("select h from Hashtag h where h.member = :member and h.profile = true")
+    List<Hashtag> findHashtagUseProfile(@Param("member") Member member);
+
+    List<Hashtag> findByMemberAndTag(Member member, String tag);
+
 }

--- a/src/main/java/pickRAP/server/repository/hashtag/HashtagRepositoryCustom.java
+++ b/src/main/java/pickRAP/server/repository/hashtag/HashtagRepositoryCustom.java
@@ -1,11 +1,17 @@
 package pickRAP.server.repository.hashtag;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import pickRAP.server.controller.dto.Hashtag.HashtagResponse;
 import pickRAP.server.controller.dto.analysis.HashTagResponse;
 import pickRAP.server.controller.dto.analysis.HashtagFilterCondition;
+import pickRAP.server.domain.member.Member;
 
 import java.util.List;
 
 public interface HashtagRepositoryCustom {
 
     List<HashTagResponse> getHashtagAnalysisResults(HashtagFilterCondition hashtagFilterCondition, String email);
+
+    Slice<HashtagResponse> findSliceHashtagResponse(Member member, Pageable pageable);
 }

--- a/src/main/java/pickRAP/server/repository/hashtag/HashtagRepositoryImpl.java
+++ b/src/main/java/pickRAP/server/repository/hashtag/HashtagRepositoryImpl.java
@@ -106,11 +106,11 @@ public class HashtagRepositoryImpl implements HashtagRepositoryCustom {
     @Override
     public Slice<HashtagResponse> findSliceHashtagResponse(Member member, Pageable pageable) {
         List<HashtagResponse> hashtagResponses = jpaQueryFactory
-                .select(new QHashtagResponse(hashtag.tag, hashtag.profile))
+                .select(new QHashtagResponse(hashtag.tag, hashtag.usedInProfile))
                 .from(hashtag)
                 .where(hashtag.member.eq(member))
-                .groupBy(hashtag.tag, hashtag.profile)
-                .orderBy(hashtag.profile.desc(), hashtag.tag.asc())
+                .groupBy(hashtag.tag, hashtag.usedInProfile)
+                .orderBy(hashtag.usedInProfile.desc(), hashtag.tag.asc())
                 .offset(pageable.getPageNumber())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();

--- a/src/main/java/pickRAP/server/repository/member/MemberRepository.java
+++ b/src/main/java/pickRAP/server/repository/member/MemberRepository.java
@@ -1,6 +1,8 @@
 package pickRAP.server.repository.member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import pickRAP.server.domain.member.Member;
 
 import java.util.Optional;
@@ -11,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
 
+    @Query("select count(m) from Member m where m <> :member and m.nickname = :nickname")
+    int getNicknameCount(@Param("member") Member member, @Param("nickname") String nickname);
 }

--- a/src/main/java/pickRAP/server/service/auth/AuthService.java
+++ b/src/main/java/pickRAP/server/service/auth/AuthService.java
@@ -48,7 +48,6 @@ public class AuthService {
                 .email(memberSignUpRequest.getEmail())
                 .name(memberSignUpRequest.getName())
                 .password(passwordEncoder.encode(memberSignUpRequest.getPassword()))
-                .profileImageUrl(DefaultImageEnv.DEFAULT_IMAGE_URL)
                 .socialType(SocialType.NONE)
                 .build();
         memberRepository.save(member);

--- a/src/main/java/pickRAP/server/service/auth/DefaultImageEnv.java
+++ b/src/main/java/pickRAP/server/service/auth/DefaultImageEnv.java
@@ -1,5 +1,0 @@
-package pickRAP.server.service.auth;
-
-public interface DefaultImageEnv {
-    public static final String DEFAULT_IMAGE_URL ="https://pickrap-s3-bucket.s3.ap-northeast-2.amazonaws.com/profile/user_default_profile.png";
-}

--- a/src/main/java/pickRAP/server/service/auth/DefaultProfileEnv.java
+++ b/src/main/java/pickRAP/server/service/auth/DefaultProfileEnv.java
@@ -1,0 +1,9 @@
+package pickRAP.server.service.auth;
+
+public interface DefaultProfileEnv {
+    public static final String DEFAULT_IMAGE_URL = "https://pickrap-s3-bucket.s3.ap-northeast-2.amazonaws.com/profile/user_default_profile.png";
+
+    public static final String DEFAULT_NICKNAME = "유저 이름";
+
+    public static final String DEFAULT_INTRODUCTION = "유저 소개글";
+}

--- a/src/main/java/pickRAP/server/service/oauth/KakaoEnv.java
+++ b/src/main/java/pickRAP/server/service/oauth/KakaoEnv.java
@@ -2,7 +2,6 @@ package pickRAP.server.service.oauth;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,7 +21,6 @@ import pickRAP.server.domain.member.Member;
 import pickRAP.server.domain.member.SocialType;
 import pickRAP.server.repository.member.MemberRepository;
 import pickRAP.server.service.auth.AuthService;
-import pickRAP.server.service.auth.DefaultImageEnv;
 import pickRAP.server.service.category.CategoryService;
 
 @Slf4j
@@ -119,7 +117,6 @@ public class KakaoEnv implements ProviderEnv{
                     .email(Long.toString(profile.getId()) + profile.getKakao_account().getEmail())
                     .password(passwordEncoder.encode(profile.getKakao_account().getEmail()))
                     .name(profile.getKakao_account().getProfile().getNickname())
-                    .profileImageUrl(DefaultImageEnv.DEFAULT_IMAGE_URL)
                     .socialType(SocialType.KAKAO)
                     .build();
             memberRepository.save(member);

--- a/src/main/java/pickRAP/server/service/oauth/NaverEnv.java
+++ b/src/main/java/pickRAP/server/service/oauth/NaverEnv.java
@@ -22,7 +22,6 @@ import pickRAP.server.domain.member.Member;
 import pickRAP.server.domain.member.SocialType;
 import pickRAP.server.repository.member.MemberRepository;
 import pickRAP.server.service.auth.AuthService;
-import pickRAP.server.service.auth.DefaultImageEnv;
 import pickRAP.server.service.category.CategoryService;
 
 import java.net.URLDecoder;
@@ -124,7 +123,6 @@ public class NaverEnv implements ProviderEnv{
                     .email(profile.getResponse().getId() + profile.getResponse().getEmail())
                     .name(URLDecoder.decode(profile.getResponse().getName(), CharsetUtil.UTF_8))
                     .password(passwordEncoder.encode(profile.getResponse().getEmail()))
-                    .profileImageUrl(DefaultImageEnv.DEFAULT_IMAGE_URL)
                     .socialType(SocialType.NAVER)
                     .build();
             memberRepository.save(member);

--- a/src/main/java/pickRAP/server/service/profile/ProfileService.java
+++ b/src/main/java/pickRAP/server/service/profile/ProfileService.java
@@ -94,7 +94,7 @@ public class ProfileService {
     }
 
     private void updateProfileHashtag(Member member, ProfileRequest profileRequest) {
-        List<Hashtag> useHashtags = hashtagRepository.findHashtagUseProfile(member);
+        List<Hashtag> useHashtags = hashtagRepository.findHashtagUsedInProfile(member);
         useHashtags.forEach(h -> h.updateProfile(false));
 
         profileRequest.getHashtags().forEach(

--- a/src/main/java/pickRAP/server/service/profile/ProfileService.java
+++ b/src/main/java/pickRAP/server/service/profile/ProfileService.java
@@ -4,10 +4,23 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import pickRAP.server.common.BaseException;
+import pickRAP.server.controller.dto.Hashtag.HashtagResponse;
 import pickRAP.server.controller.dto.profile.ProfileRequest;
 import pickRAP.server.controller.dto.profile.ProfileResponse;
+import pickRAP.server.domain.hashtag.Hashtag;
 import pickRAP.server.domain.member.Member;
+import pickRAP.server.repository.hashtag.HashtagRepository;
 import pickRAP.server.repository.member.MemberRepository;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static pickRAP.server.common.BaseExceptionStatus.*;
+import static pickRAP.server.util.s3.S3Util.uploadFile;
 
 @Slf4j
 @Service
@@ -15,24 +28,80 @@ import pickRAP.server.repository.member.MemberRepository;
 public class ProfileService {
     private final MemberRepository memberRepository;
 
+    private final HashtagRepository hashtagRepository;
+
+    //프로필 정보 가져오기
     @Transactional
     public ProfileResponse getProfile (String email) {
         Member member = memberRepository.findByEmail(email).orElseThrow();
+        List<String> useHashtags = hashtagRepository.findTagDistinct(member, true);
 
-        String[] keywords = member.getKeyword().split("#");
+        List<HashtagResponse> hashtagResponses = useHashtags.stream().map(
+            h -> HashtagResponse.builder().tag(h).use(true).build()
+        ).collect(Collectors.toList());
 
-        return new ProfileResponse(member.getName(), member.getIntroduction(), member.getProfileImageUrl(), keywords);
+        return ProfileResponse.builder()
+                .nickname(member.getNickname())
+                .introduction(member.getIntroduction())
+                .profileImageUrl(member.getProfileImageUrl())
+                .hashtags(hashtagResponses)
+                .build();
     }
 
+    //프로필 정보 수정하기
     @Transactional
-    public void updateProfile(String email, ProfileRequest request, String profileImageUrl) {
+    public void updateProfile(String email, ProfileRequest profileRequest, MultipartFile multipartFile) {
         Member member = memberRepository.findByEmail(email).orElseThrow();
 
-        String keyword = "";
-        for(String k : request.getKeywords()) {
-            keyword += k + "#";
+        validateIntroduction(profileRequest.getIntroduction());
+        validateNickname(member, profileRequest.getNickname());
+        validateHashtags(profileRequest.getHashtags());
+
+        String profileImageUrl = member.getProfileImageUrl();
+        //MultipartFile 테스트를 위해 이중으로 처리
+        if(!Objects.isNull(multipartFile)) {
+            if (!multipartFile.isEmpty()) {
+                profileImageUrl = uploadFile(multipartFile, "profile", "image");
+            }
         }
-        member.updateProfile(request.getName(), request.getIntroduction(), profileImageUrl, keyword);
+
+        member.updateProfile(profileRequest.getNickname(), profileRequest.getIntroduction(), profileImageUrl);
+        updateProfileHashtag(member, profileRequest);
     }
 
+    private void validateIntroduction(String introduction) {
+        if (!StringUtils.hasText(introduction)) {
+            throw new BaseException(EMPTY_INPUT_VALUE);
+        }
+        if (introduction.length() > 25) {
+            throw new BaseException(INTRODUCTION_LONG);
+        }
+    }
+
+    private void validateNickname(Member member, String nickname) {
+        if (!StringUtils.hasText(nickname)) {
+            throw new BaseException(EMPTY_INPUT_VALUE);
+        }
+        if (memberRepository.getNicknameCount(member, nickname) != 0) {
+            throw new BaseException(DUPLICATE_NICKNAME);
+        }
+    }
+
+    private void validateHashtags(List<String> hashtags) {
+        if (hashtags.size() > 4) {
+            throw new BaseException(EXCEED_HASHTAG);
+        }
+    }
+
+    private void updateProfileHashtag(Member member, ProfileRequest profileRequest) {
+        List<Hashtag> useHashtags = hashtagRepository.findHashtagUseProfile(member);
+        useHashtags.forEach(h -> h.updateProfile(false));
+
+        profileRequest.getHashtags().forEach(
+            tag -> {
+                List<Hashtag> hashtags = hashtagRepository.findByMemberAndTag(member, tag);
+                hashtags.forEach(h ->h.updateProfile(true));
+            }
+        );
+    }
 }

--- a/src/main/java/pickRAP/server/service/scrap/ScrapService.java
+++ b/src/main/java/pickRAP/server/service/scrap/ScrapService.java
@@ -285,16 +285,16 @@ public class ScrapService {
 
         for(String hashtagRequest : hashtagRequests) {
             List<Hashtag> findHashtags = hashtagRepository.findByMemberAndTag(member, hashtagRequest);
-            boolean profile = false;
-            if(!findHashtags.isEmpty() && findHashtags.get(0).isProfile()) {
-                profile = true;
+            boolean usedInProfile = false;
+            if(!findHashtags.isEmpty() && findHashtags.get(0).isUsedInProfile()) {
+                usedInProfile = true;
             }
 
             Hashtag hashtag = Hashtag.builder()
                     .tag(hashtagRequest)
                     .member(member)
                     .build();
-            hashtag.updateProfile(profile);
+            hashtag.updateProfile(usedInProfile);
 
             hashtags.add(hashtag);
             hashtagRepository.save(hashtag);

--- a/src/main/java/pickRAP/server/service/scrap/ScrapService.java
+++ b/src/main/java/pickRAP/server/service/scrap/ScrapService.java
@@ -284,10 +284,17 @@ public class ScrapService {
         List<Hashtag> hashtags = new ArrayList<>();
 
         for(String hashtagRequest : hashtagRequests) {
+            List<Hashtag> findHashtags = hashtagRepository.findByMemberAndTag(member, hashtagRequest);
+            boolean profile = false;
+            if(!findHashtags.isEmpty() && findHashtags.get(0).isProfile()) {
+                profile = true;
+            }
+
             Hashtag hashtag = Hashtag.builder()
                     .tag(hashtagRequest)
                     .member(member)
                     .build();
+            hashtag.updateProfile(profile);
 
             hashtags.add(hashtag);
             hashtagRepository.save(hashtag);
@@ -339,14 +346,18 @@ public class ScrapService {
     }
 
     private void saveTextByScrap(Scrap scrap, Member member, boolean update) {
-        textService.save(member, scrap.getMemo());
+        if (StringUtils.hasText(scrap.getMemo())) {
+            textService.save(member, scrap.getMemo());
+        }
         if (scrap.getScrapType() == ScrapType.TEXT && !update) {
             textService.save(member, scrap.getContent());
         }
     }
 
     private void deleteTextByScrap(Scrap scrap, Member member, boolean update) {
-        textService.delete(member, scrap.getMemo());
+        if (StringUtils.hasText(scrap.getMemo())) {
+            textService.delete(member, scrap.getMemo());
+        }
         if (scrap.getScrapType() == ScrapType.TEXT && !update) {
             textService.delete(member, scrap.getContent());
         }

--- a/src/test/java/pickRAP/server/profile/ProfileServiceTest.java
+++ b/src/test/java/pickRAP/server/profile/ProfileServiceTest.java
@@ -1,0 +1,189 @@
+package pickRAP.server.profile;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
+import org.springframework.transaction.annotation.Transactional;
+import pickRAP.server.config.security.jwt.TokenDto;
+import pickRAP.server.controller.dto.auth.MemberSignInRequest;
+import pickRAP.server.controller.dto.auth.MemberSignUpRequest;
+import pickRAP.server.controller.dto.profile.ProfileRequest;
+import pickRAP.server.controller.dto.profile.ProfileResponse;
+import pickRAP.server.controller.dto.scrap.ScrapRequest;
+import pickRAP.server.domain.member.Member;
+import pickRAP.server.repository.member.MemberRepository;
+import pickRAP.server.service.auth.AuthService;
+import pickRAP.server.service.profile.ProfileService;
+import pickRAP.server.service.scrap.ScrapService;
+
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.apache.http.HttpHeaders.AUTHORIZATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static pickRAP.server.auth.AuthEnv.EMAIL_OK;
+import static pickRAP.server.auth.AuthEnv.PASSWORD_OK;
+import static pickRAP.server.service.auth.DefaultProfileEnv.*;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+public class ProfileServiceTest {
+
+    @Autowired AuthService authService;
+
+    @Autowired ScrapService scrapService;
+
+    @Autowired ProfileService profileService;
+
+    @Autowired MemberRepository memberRepository;
+
+    @Autowired ObjectMapper objectMapper;
+
+    @Autowired private MockMvc mockMvc;
+
+    private final String UPDATE_NICKNAME = "pickrap";
+
+    private final String UPDATE_INTRODUCTION = "pickrap ZZang";
+
+    private final List<String> HASHTAGS = List.of("#profile", "#test", "#hashtag");
+
+
+    private MemberSignUpRequest memberSignUpRequest() {
+        return MemberSignUpRequest.builder()
+                .email(EMAIL_OK)
+                .password(PASSWORD_OK)
+                .name("테스트유저")
+                .build();
+    }
+
+    private MemberSignInRequest memberSignInRequest() {
+        return MemberSignInRequest.builder()
+                .email(EMAIL_OK)
+                .password(PASSWORD_OK)
+                .build();
+    }
+
+    private ScrapRequest scrapRequest() {
+        return ScrapRequest.builder()
+                .title("title")
+                .scrapType("text")
+                .content("content")
+                .hashtags(HASHTAGS)
+                .build();
+    }
+
+    private ProfileRequest profileRequest() {
+        return ProfileRequest.builder()
+                .nickname(UPDATE_NICKNAME)
+                .introduction(UPDATE_INTRODUCTION)
+                .hashtags(HASHTAGS)
+                .build();
+    }
+
+    @BeforeEach
+    void before() {
+        MemberSignUpRequest memberSignUpRequest = memberSignUpRequest();
+
+        authService.signUp(memberSignUpRequest);
+    }
+
+    @Test
+    @DisplayName("프로필 테스트 - 기본")
+    void getProfileTest() {
+        //given
+        Member member = memberRepository.findByEmail(EMAIL_OK).get();
+
+        //when
+        ProfileResponse profile = profileService.getProfile(member.getEmail());
+
+        //then
+        assertThat(profile.getNickname()).isEqualTo(DEFAULT_NICKNAME);
+        assertThat(profile.getIntroduction()).isEqualTo(DEFAULT_INTRODUCTION);
+        assertThat(profile.getProfileImageUrl()).isEqualTo(DEFAULT_IMAGE_URL);
+        assertThat(profile.getHashtags().size()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("프로필 테스트 - 수정(사진X)")
+    void updateBasicProfileTest() {
+        //given
+        Member member = memberRepository.findByEmail(EMAIL_OK).get();
+        ScrapRequest scrapRequest = scrapRequest();
+        ProfileRequest profileRequest = profileRequest();
+
+        scrapService.save(scrapRequest, null, member.getEmail());
+
+        //when
+        profileService.updateProfile(member.getEmail(), profileRequest, null);
+        ProfileResponse profile = profileService.getProfile(member.getEmail());
+
+        //then
+        assertThat(profile.getNickname()).isEqualTo(UPDATE_NICKNAME);
+        assertThat(profile.getIntroduction()).isEqualTo(UPDATE_INTRODUCTION);
+        assertThat(profile.getProfileImageUrl()).isEqualTo(DEFAULT_IMAGE_URL);
+        assertThat(profile.getHashtags().size()).isEqualTo(HASHTAGS.size());
+    }
+
+    @Test
+    @DisplayName("프로필 테스트 - 수정(사진O)")
+    void updateProfileTest() throws Exception {
+        //given
+        MemberSignInRequest memberSignInRequest = memberSignInRequest();
+        TokenDto tokenDto = authService.signIn(memberSignInRequest);
+
+        Member member = memberRepository.findByEmail(EMAIL_OK).get();
+        ScrapRequest scrapRequest = scrapRequest();
+        ProfileRequest profileRequest = profileRequest();
+
+        scrapService.save(scrapRequest, null, member.getEmail());
+
+        String content = objectMapper.writeValueAsString(profileRequest);
+        final String fileName = "test_image";
+        final String contentType = "gif";
+        final String filePath = "src/test/resources/image/" + fileName + "." + contentType;
+        FileInputStream fileInputStream = new FileInputStream(filePath);
+
+        MockMultipartFile image =
+                new MockMultipartFile("file", fileName + "." + contentType, "image/" + contentType, fileInputStream);
+
+        MockMultipartFile json =
+                new MockMultipartFile("profile_request", "jsondata", "application/json", content.getBytes(StandardCharsets.UTF_8));
+
+        MockMultipartHttpServletRequestBuilder builder = multipart("/profile");
+        builder.with(request -> {
+            request.setMethod("PUT");
+            return request;
+        });
+
+        //when
+        mockMvc.perform(
+                builder.file(json)
+                        .file(image)
+                        .header(AUTHORIZATION, "Bearer " + tokenDto.getAccessToken())
+                        .contentType("multipart/mixed")
+                        .accept(APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andExpect(status().isOk())
+                .andDo(print());
+        ProfileResponse profile = profileService.getProfile(member.getEmail());
+
+        //then
+        assertThat(profile.getNickname()).isEqualTo(UPDATE_NICKNAME);
+        assertThat(profile.getIntroduction()).isEqualTo(UPDATE_INTRODUCTION);
+        assertThat(profile.getHashtags().size()).isEqualTo(HASHTAGS.size());
+        assertThat(profile.getProfileImageUrl()).isNotEqualTo(DEFAULT_IMAGE_URL);
+    }
+}


### PR DESCRIPTION
## 📮 관련 이슈
- Resolved: #163 

## ⛳️ 작업 내용

- 해시태그 조회 (중복제거, 페이징, 프로필에 사용중인 해시태그 우선순위)
- 프로필 조회
- 프로필 수정

## 🌱 PR 포인트
- 해시태그 테이블에 **profile** 컬럼 추가
- 프로필에 사용되는 해시태그는 **profile** 컬럼에 Y, 사용되지 않는 해시태그는 N 삽입
- 닉네임 중복 불가

## 📸 스크린샷
|해시태그 조회|
|:--:|
|<img width="1078" alt="스크린샷 2023-03-10 오후 6 37 11" src="https://user-images.githubusercontent.com/102985637/224280558-1291cd98-6ebb-4f79-9faa-22122293e009.png">|
|프로필 조회|
|<img width="1075" alt="스크린샷 2023-03-10 오후 6 36 56" src="https://user-images.githubusercontent.com/102985637/224280733-2cb03599-7cdf-4852-81fd-2703def69121.png">|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
